### PR TITLE
fix(config): change enumDeclaration.memberSpacing options to camelCase

### DIFF
--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -81,18 +81,18 @@ pub enum MemberSpacing {
     /// Maintains whether a newline or blankline is used.
     Maintain,
     /// Forces a new line between members.
-    #[serde(rename = "newline")]
+    #[serde(rename = "newLine")]
     NewLine,
     /// Forces a blank line between members.
-    #[serde(rename = "blankline")]
+    #[serde(rename = "blankLine")]
     BlankLine,
 }
 
 generate_str_to_from![
     MemberSpacing,
     [Maintain, "maintain"],
-    [BlankLine, "blankline"],
-    [NewLine, "newline"]
+    [BlankLine, "blankLine"],
+    [NewLine, "newLine"]
 ];
 
 /// Where to place the next control flow within a control flow statement.

--- a/tests/specs/declarations/enum/EnumDeclaration_MemberSpacing_Blankline.txt
+++ b/tests/specs/declarations/enum/EnumDeclaration_MemberSpacing_Blankline.txt
@@ -1,5 +1,5 @@
-~~ enumDeclaration.memberSpacing: blankline ~~
-== should format with blanklines ==
+~~ enumDeclaration.memberSpacing: blankLine ~~
+== should format with blankLines ==
 declare enum Test {
     member1,
 

--- a/tests/specs/declarations/enum/EnumDeclaration_MemberSpacing_Newline.txt
+++ b/tests/specs/declarations/enum/EnumDeclaration_MemberSpacing_Newline.txt
@@ -1,5 +1,5 @@
-~~ enumDeclaration.memberSpacing: newline ~~
-== should format with newlines ==
+~~ enumDeclaration.memberSpacing: newLine ~~
+== should format with newLines ==
 declare enum Test {
     member1,
 


### PR DESCRIPTION
dprint uses camelcase for its configuration options. This change modifies the enumDeclaration.memberSpacing options to conform to this standard.