### PR TITLE
upgrade: swc_ecmascript, swc_common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ wasm = ["serde_json", "dprint-core/wasm"]
 
 [dependencies]
 dprint-core = { version = "0.31.0", features = ["formatting"] }
-swc_common = "=0.10.5"
-swc_ecmascript = { version = "=0.14.1", features = ["parser"] }
+swc_common = "0.10.6"
+swc_ecmascript = { version = "0.14.4", features = ["parser"] }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 


### PR DESCRIPTION
Upgrades swc related crates to latest versions and unpins them.

Closes https://github.com/dprint/dprint-plugin-typescript/issues/78