### PR TITLE
fix: Don't add second ? to optional methods

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -618,7 +618,7 @@ fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> PrintItem
     let mut items = PrintItems::new();
     items.push_str(node.sym() as &str);
 
-    if node.optional() && !node.parent().unwrap().is::<ClassProp>() {
+    if node.optional() && !node.parent().unwrap().is::<ClassProp>() && !node.parent().unwrap().is::<ClassMethod>() {
         items.push_str("?");
     }
     if let Node::VarDeclarator(node) = node.parent().unwrap() {

--- a/tests/specs/declarations/class/method/ClassMethod_All.txt
+++ b/tests/specs/declarations/class/method/ClassMethod_All.txt
@@ -33,6 +33,9 @@ abstract class Test {
     method8(): string | number | string | number | string {
     }
 
+    method9?() {
+    }
+
     get getSet(): string {
     }
 
@@ -80,6 +83,9 @@ abstract class Test {
         | number
         | string
     {
+    }
+
+    method9?() {
     }
 
     get getSet(): string {

--- a/tests/specs/declarations/class/private_method/PrivateMethod_All.txt
+++ b/tests/specs/declarations/class/private_method/PrivateMethod_All.txt
@@ -4,11 +4,17 @@ abstract class Test {
     #method1(   arg   : string  )   : test {
         return    5   ;
     }
+
+    #method2?() {
+    }
 }
 
 [expect]
 abstract class Test {
     #method1(arg: string): test {
         return 5;
+    }
+
+    #method2?() {
     }
 }


### PR DESCRIPTION
The `?` symbols in optional class methods were being doubled for the same reason as in 1a9e904ccfd6237b04ee7ae01b3e1d7df27eeae7. This fixes that.