### PR TITLE
Flatten member-like expressions before parsing to dprint-core IR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ dprint-core = { version = "0.35.1", features = ["formatting"] }
 fnv = "1.0.3"
 swc_common = "0.10.9"
 swc_ecmascript = { version = "0.20.0", features = ["parser"] }
-swc_ast_view = { version = "0.8.0", package = "dprint-swc-ecma-ast-view" }
+swc_ast_view = { version = "0.8.1", package = "dprint-swc-ecma-ast-view" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 

--- a/src/parsing/swc/flatten_member_like_expr.rs
+++ b/src/parsing/swc/flatten_member_like_expr.rs
@@ -1,0 +1,63 @@
+use swc_ast_view::*;
+
+pub struct FlattenedMemberLikeExpr<'a> {
+    pub node: Node<'a>,
+
+    pub nodes: Vec<MemberLikeExprItem<'a>>,
+}
+
+pub struct MemberLikeExprItem<'a> {
+    pub is_computed: bool,
+    pub node: Node<'a>,
+}
+
+/// Takes a member expression and flattens it out.
+/// This is done to prevent a stack overflow when someone has many chained member expressions.
+pub fn flatten_member_expr<'a>(member_expr: &MemberExpr<'a>) -> FlattenedMemberLikeExpr<'a> {
+    let mut nodes = Vec::new();
+    push_descendant_nodes(member_expr.into(), &mut nodes);
+
+    FlattenedMemberLikeExpr {
+        node: member_expr.into(),
+        nodes,
+    }
+}
+
+pub fn flatten_meta_prop_expr<'a>(meta_prop_expr: &MetaPropExpr<'a>) -> FlattenedMemberLikeExpr<'a> {
+    let mut nodes = Vec::new();
+    push_descendant_nodes(meta_prop_expr.into(), &mut nodes);
+
+    FlattenedMemberLikeExpr {
+        node: meta_prop_expr.into(),
+        nodes,
+    }
+}
+
+fn push_descendant_nodes<'a>(node: Node<'a>, nodes: &mut Vec<MemberLikeExprItem<'a>>) {
+    match node {
+        Node::MemberExpr(member_expr) => {
+            push_descendant_nodes(member_expr.obj.into(), nodes);
+            if member_expr.computed() {
+                nodes.push(MemberLikeExprItem {
+                    node: member_expr.prop.into(),
+                    is_computed: true,
+                });
+            } else {
+                push_descendant_nodes(member_expr.prop.into(), nodes);
+            }
+        }
+        Node::MetaPropExpr(meta_prop_expr) => {
+            push_descendant_nodes(meta_prop_expr.meta.into(), nodes);
+            push_descendant_nodes(meta_prop_expr.prop.into(), nodes);
+        }
+        Node::OptChainExpr(opt_chain_expr) => {
+            push_descendant_nodes(opt_chain_expr.expr.into(), nodes);
+        }
+        node => {
+            nodes.push(MemberLikeExprItem {
+                is_computed: false,
+                node,
+            });
+        },
+    }
+}

--- a/src/parsing/swc/flatten_member_like_expr.rs
+++ b/src/parsing/swc/flatten_member_like_expr.rs
@@ -1,4 +1,5 @@
 use swc_ast_view::*;
+use super::super::node_helpers;
 
 pub struct FlattenedMemberLikeExpr<'a> {
     pub node: Node<'a>,
@@ -6,58 +7,91 @@ pub struct FlattenedMemberLikeExpr<'a> {
     pub nodes: Vec<MemberLikeExprItem<'a>>,
 }
 
-pub struct MemberLikeExprItem<'a> {
-    pub is_computed: bool,
-    pub node: Node<'a>,
+pub enum MemberLikeExprItem<'a> {
+    Computed(Node<'a>),
+    Node(Node<'a>),
+    CallExpr(Box<MemberLikeExprItemCallExpr<'a>>),
+}
+
+impl<'a> Spanned for MemberLikeExprItem<'a> {
+    fn span(&self) -> Span {
+        match self {
+            MemberLikeExprItem::Computed(node) => node.span(),
+            MemberLikeExprItem::Node(node) => node.span(),
+            MemberLikeExprItem::CallExpr(call_expr) => {
+                Span::new(call_expr.callee.span().lo(), call_expr.original_call_expr.hi(), Default::default())
+            }
+        }
+    }
+}
+
+impl<'a> MemberLikeExprItem<'a> {
+    pub fn is_computed(&self) -> bool {
+        matches!(self, MemberLikeExprItem::Computed(_))
+    }
+
+    pub fn is_optional(&self) -> bool {
+        self.get_top_node().parent().unwrap().parent().unwrap().kind() == NodeKind::OptChainExpr
+    }
+
+    fn get_top_node(&self) -> Node<'a> {
+        match self {
+            MemberLikeExprItem::Computed(node) => *node,
+            MemberLikeExprItem::Node(node) => *node,
+            MemberLikeExprItem::CallExpr(call_expr) => call_expr.original_call_expr.into(),
+        }
+    }
+}
+
+pub struct MemberLikeExprItemCallExpr<'a> {
+    pub original_call_expr: &'a CallExpr<'a>,
+    pub callee: MemberLikeExprItem<'a>,
 }
 
 /// Takes a member expression and flattens it out.
 /// This is done to prevent a stack overflow when someone has many chained member expressions.
-pub fn flatten_member_expr<'a>(member_expr: &MemberExpr<'a>) -> FlattenedMemberLikeExpr<'a> {
+pub fn flatten_member_like_expr<'a>(node: Node<'a>, module: &Module<'a>) -> FlattenedMemberLikeExpr<'a> {
     let mut nodes = Vec::new();
-    push_descendant_nodes(member_expr.into(), &mut nodes);
+    push_descendant_nodes(node, &mut nodes, module);
 
     FlattenedMemberLikeExpr {
-        node: member_expr.into(),
+        node,
         nodes,
     }
 }
 
-pub fn flatten_meta_prop_expr<'a>(meta_prop_expr: &MetaPropExpr<'a>) -> FlattenedMemberLikeExpr<'a> {
-    let mut nodes = Vec::new();
-    push_descendant_nodes(meta_prop_expr.into(), &mut nodes);
-
-    FlattenedMemberLikeExpr {
-        node: meta_prop_expr.into(),
-        nodes,
-    }
-}
-
-fn push_descendant_nodes<'a>(node: Node<'a>, nodes: &mut Vec<MemberLikeExprItem<'a>>) {
+fn push_descendant_nodes<'a>(node: Node<'a>, nodes: &mut Vec<MemberLikeExprItem<'a>>, module: &Module<'a>) {
     match node {
         Node::MemberExpr(member_expr) => {
-            push_descendant_nodes(member_expr.obj.into(), nodes);
+            push_descendant_nodes(member_expr.obj.into(), nodes, module);
             if member_expr.computed() {
-                nodes.push(MemberLikeExprItem {
-                    node: member_expr.prop.into(),
-                    is_computed: true,
-                });
+                nodes.push(MemberLikeExprItem::Computed(member_expr.prop.into()));
             } else {
-                push_descendant_nodes(member_expr.prop.into(), nodes);
+                push_descendant_nodes(member_expr.prop.into(), nodes, module);
             }
         }
         Node::MetaPropExpr(meta_prop_expr) => {
-            push_descendant_nodes(meta_prop_expr.meta.into(), nodes);
-            push_descendant_nodes(meta_prop_expr.prop.into(), nodes);
+            push_descendant_nodes(meta_prop_expr.meta.into(), nodes, module);
+            push_descendant_nodes(meta_prop_expr.prop.into(), nodes, module);
         }
         Node::OptChainExpr(opt_chain_expr) => {
-            push_descendant_nodes(opt_chain_expr.expr.into(), nodes);
+            push_descendant_nodes(opt_chain_expr.expr.into(), nodes, module);
+        }
+        Node::CallExpr(call_expr) => {
+            // leave test library call expressions as-is
+            if node_helpers::is_test_library_call_expr(call_expr, module) {
+                nodes.push(MemberLikeExprItem::Node(node));
+            } else {
+                push_descendant_nodes(call_expr.callee.into(), nodes, module);
+                let new_call_expr_callee = nodes.pop().unwrap();
+                nodes.push(MemberLikeExprItem::CallExpr(Box::new(MemberLikeExprItemCallExpr {
+                    original_call_expr: call_expr,
+                    callee: new_call_expr_callee,
+                })));
+            }
         }
         node => {
-            nodes.push(MemberLikeExprItem {
-                is_computed: false,
-                node,
-            });
+            nodes.push(MemberLikeExprItem::Node(node));
         },
     }
 }

--- a/src/parsing/swc/mod.rs
+++ b/src/parsing/swc/mod.rs
@@ -1,5 +1,7 @@
 mod extensions;
 mod flatten_binary_expr;
+mod flatten_member_like_expr;
 
 pub use extensions::*;
 pub use flatten_binary_expr::*;
+pub use flatten_member_like_expr::*;


### PR DESCRIPTION
This actually makes it simpler.

Todo:

- [x] Test this actually fixes the stack overflow seen in WASM. It still uses recursion to flatten the member-like expressions.
- [x] Tested and it didn't work. Need to also include call expressions in this.

Closes #105