### PR TITLE
Add options objectExpression.spaceSurroundingProperties et al.

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -315,6 +315,22 @@ impl ConfigurationBuilder {
         self.insert("jsxExpressionContainer.spaceSurroundingExpression", value.into())
     }
 
+    /// Whether to add a space surrounding the properties of an object expression.
+    ///
+    /// * `true` (default) - Ex. `{ key: value }`
+    /// * `false` - Ex. `{key: value}`
+    pub fn object_expression_space_surrounding_properties(&mut self, value: bool) -> &mut Self {
+        self.insert("objectExpression.spaceSurroundingProperties", value.into())
+    }
+
+    /// Whether to add a space surrounding the properties of an object pattern.
+    ///
+    /// * `true` (default) - Ex. `{ key: value } = obj`
+    /// * `false` - Ex. `{key: value} = obj`
+    pub fn object_pattern_space_surrounding_properties(&mut self, value: bool) -> &mut Self {
+        self.insert("objectPattern.spaceSurroundingProperties", value.into())
+    }
+
     /// Whether to add a space before the parentheses of a method.
     ///
     /// `true` - Ex. `myMethod ()`
@@ -353,6 +369,14 @@ impl ConfigurationBuilder {
     /// * `false` - Ex. `<string>myValue`
     pub fn type_assertion_space_before_expression(&mut self, value: bool) -> &mut Self {
         self.insert("typeAssertion.spaceBeforeExpression", value.into())
+    }
+
+    /// Whether to add a space surrounding the properties of a type literal.
+    ///
+    /// * `true` (default) - Ex. `value: { key: Type }`
+    /// * `false` - Ex. `value: {key: Type}`
+    pub fn type_literal_space_surrounding_properties(&mut self, value: bool) -> &mut Self {
+        self.insert("typeLiteral.spaceSurroundingProperties", value.into())
     }
 
     /// Whether to add a space after the `while` keyword in a while statement.

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -194,10 +194,13 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
         import_declaration_space_surrounding_named_imports: get_value(&mut config, "importDeclaration.spaceSurroundingNamedImports", true, &mut diagnostics),
         jsx_expression_container_space_surrounding_expression: get_value(&mut config, "jsxExpressionContainer.spaceSurroundingExpression", false, &mut diagnostics),
         method_space_before_parentheses: get_value(&mut config, "method.spaceBeforeParentheses", false, &mut diagnostics),
+        object_expression_space_surrounding_properties: get_value(&mut config, "objectExpression.spaceSurroundingProperties", true, &mut diagnostics),
+        object_pattern_space_surrounding_properties: get_value(&mut config, "objectPattern.spaceSurroundingProperties", true, &mut diagnostics),
         set_accessor_space_before_parentheses: get_value(&mut config, "setAccessor.spaceBeforeParentheses", false, &mut diagnostics),
         tagged_template_space_before_literal: get_value(&mut config, "taggedTemplate.spaceBeforeLiteral", true, &mut diagnostics),
         type_annotation_space_before_colon: get_value(&mut config, "typeAnnotation.spaceBeforeColon", false, &mut diagnostics),
         type_assertion_space_before_expression: get_value(&mut config, "typeAssertion.spaceBeforeExpression", true, &mut diagnostics),
+        type_literal_space_surrounding_properties: get_value(&mut config, "typeLiteral.spaceSurroundingProperties", true, &mut diagnostics),
         while_statement_space_after_while_keyword: get_value(&mut config, "whileStatement.spaceAfterWhileKeyword", true, &mut diagnostics),
     };
 

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -526,6 +526,10 @@ pub struct Configuration {
     pub jsx_expression_container_space_surrounding_expression: bool,
     #[serde(rename = "method.spaceBeforeParentheses")]
     pub method_space_before_parentheses: bool,
+    #[serde(rename = "objectExpression.spaceSurroundingProperties")]
+    pub object_expression_space_surrounding_properties: bool,
+    #[serde(rename = "objectPattern.spaceSurroundingProperties")]
+    pub object_pattern_space_surrounding_properties: bool,
     #[serde(rename = "setAccessor.spaceBeforeParentheses")]
     pub set_accessor_space_before_parentheses: bool,
     #[serde(rename = "taggedTemplate.spaceBeforeLiteral")]
@@ -534,6 +538,8 @@ pub struct Configuration {
     pub type_annotation_space_before_colon: bool,
     #[serde(rename = "typeAssertion.spaceBeforeExpression")]
     pub type_assertion_space_before_expression: bool,
+    #[serde(rename = "typeLiteral.spaceSurroundingProperties")]
+    pub type_literal_space_surrounding_properties: bool,
     #[serde(rename = "whileStatement.spaceAfterWhileKeyword")]
     pub while_statement_space_after_while_keyword: bool,
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2005,7 +2005,7 @@ fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> Print
         separator: context.config.object_expression_trailing_commas.into(),
         prefer_hanging: context.config.object_expression_prefer_hanging,
         prefer_single_line: context.config.object_expression_prefer_single_line,
-        surround_single_line_with_spaces: true,
+        surround_single_line_with_spaces: context.config.object_expression_space_surrounding_properties,
         allow_blank_lines: true,
         node_sorter: None,
     }, context)
@@ -2480,7 +2480,7 @@ fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintIt
         },
         prefer_hanging: context.config.type_literal_prefer_hanging,
         prefer_single_line: context.config.type_literal_prefer_single_line,
-        surround_single_line_with_spaces: true,
+        surround_single_line_with_spaces: context.config.type_literal_space_surrounding_properties,
         allow_blank_lines: true,
         node_sorter: None,
     }, context);
@@ -2951,7 +2951,7 @@ fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> Print
         separator: get_trailing_commas(node, context).into(),
         prefer_hanging: context.config.object_pattern_prefer_hanging,
         prefer_single_line: context.config.object_pattern_prefer_single_line,
-        surround_single_line_with_spaces: true,
+        surround_single_line_with_spaces: context.config.object_pattern_space_surrounding_properties,
         allow_blank_lines: true,
         node_sorter: None,
     }, context));

--- a/tests/specs/expressions/ObjectExpression/ObjectExpression_SpaceSurroundingProperties_False.txt
+++ b/tests/specs/expressions/ObjectExpression/ObjectExpression_SpaceSurroundingProperties_False.txt
@@ -1,0 +1,6 @@
+~~ objectExpression.spaceSurroundingProperties: false ~~
+== should format ==
+const obj = { key: value };
+
+[expect]
+const obj = {key: value};

--- a/tests/specs/patterns/ObjectPattern/ObjectPattern_SpaceSurroundingProperties_False.txt
+++ b/tests/specs/patterns/ObjectPattern/ObjectPattern_SpaceSurroundingProperties_False.txt
@@ -1,0 +1,6 @@
+~~ objectPattern.spaceSurroundingProperties: false ~~
+== should format ==
+const { key: value } = obj;
+
+[expect]
+const {key: value} = obj;

--- a/tests/specs/types/TypeLiteral/TypeLiteral_SpaceSurroundingProperties_False.txt
+++ b/tests/specs/types/TypeLiteral/TypeLiteral_SpaceSurroundingProperties_False.txt
@@ -1,0 +1,6 @@
+~~ typeLiteral.spaceSurroundingProperties: false ~~
+== should format ==
+let value: { key: Type };
+
+[expect]
+let value: {key: Type};


### PR DESCRIPTION
For parity with Prettier’s [`bracketSpacing`](https://prettier.io/docs/en/options.html#bracket-spacing) option.

```ts
const obj = { key: value }; // objectExpression.spaceSurroundingProperties: true (default)
const obj = {key: value}; // objectExpression.spaceSurroundingProperties: false

const { key: value } = obj; // objectPattern.spaceSurroundingProperties: true (default)
const {key: value} = obj; // objectPattern.spaceSurroundingProperties: false

let value: { key: Type }; // typeLiteral.spaceSurroundingProperties: true (default)
let value: {key: Type}; // typeLiteral.spaceSurroundingProperties: false
```

Three separate options may be overkill, but that seems to be consistent with how the other options work.