### PR TITLE
feat: Add spaceSurroundingProperties option

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -347,6 +347,14 @@ impl ConfigurationBuilder {
         self.insert("setAccessor.spaceBeforeParentheses", value.into())
     }
 
+    /// Whether to add a space surrounding the properties of object-like nodes.
+    ///
+    /// * `true` (default) - Ex. `{ key: value }`
+    /// * `false` - Ex. `{key: value}`
+    pub fn space_surrounding_properties(&mut self, value: bool) -> &mut Self {
+        self.insert("spaceSurroundingProperties", value.into())
+    }
+
     /// Whether to add a space before the literal in a tagged template.
     ///
     /// * `true` (default) - Ex. `html \`<element />\``
@@ -1051,6 +1059,7 @@ mod tests {
             .object_expression_space_surrounding_properties(false)
             .object_pattern_space_surrounding_properties(false)
             .set_accessor_space_before_parentheses(true)
+            .space_surrounding_properties(false)
             .tagged_template_space_before_literal(false)
             .type_annotation_space_before_colon(true)
             .type_assertion_space_before_expression(true)
@@ -1058,7 +1067,7 @@ mod tests {
             .while_statement_space_after_while_keyword(true);
 
         let inner_config = config.get_inner_config();
-        assert_eq!(inner_config.len(), 148);
+        assert_eq!(inner_config.len(), 149);
         let diagnostics = resolve_config(inner_config, &resolve_global_config(HashMap::new()).config).diagnostics;
         assert_eq!(diagnostics.len(), 0);
     }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -42,6 +42,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     let prefer_hanging = get_value(&mut config, "preferHanging", false, &mut diagnostics);
     let prefer_single_line_nullable = get_nullable_value(&mut config, "preferSingleLine", &mut diagnostics);
     let prefer_single_line = prefer_single_line_nullable.unwrap_or(false);
+    let space_surrounding_properties = get_value(&mut config, "spaceSurroundingProperties", true, &mut diagnostics);
     let type_literal_separator_kind = get_value(&mut config, "typeLiteral.separatorKind", SemiColonOrComma::SemiColon, &mut diagnostics);
 
     // todo: remove these two lines after 2021-03
@@ -194,13 +195,14 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
         import_declaration_space_surrounding_named_imports: get_value(&mut config, "importDeclaration.spaceSurroundingNamedImports", true, &mut diagnostics),
         jsx_expression_container_space_surrounding_expression: get_value(&mut config, "jsxExpressionContainer.spaceSurroundingExpression", false, &mut diagnostics),
         method_space_before_parentheses: get_value(&mut config, "method.spaceBeforeParentheses", false, &mut diagnostics),
-        object_expression_space_surrounding_properties: get_value(&mut config, "objectExpression.spaceSurroundingProperties", true, &mut diagnostics),
-        object_pattern_space_surrounding_properties: get_value(&mut config, "objectPattern.spaceSurroundingProperties", true, &mut diagnostics),
+        object_expression_space_surrounding_properties: get_value(&mut config, "objectExpression.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),
+        object_pattern_space_surrounding_properties: get_value(&mut config, "objectPattern.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),
         set_accessor_space_before_parentheses: get_value(&mut config, "setAccessor.spaceBeforeParentheses", false, &mut diagnostics),
+        space_surrounding_properties,
         tagged_template_space_before_literal: get_value(&mut config, "taggedTemplate.spaceBeforeLiteral", true, &mut diagnostics),
         type_annotation_space_before_colon: get_value(&mut config, "typeAnnotation.spaceBeforeColon", false, &mut diagnostics),
         type_assertion_space_before_expression: get_value(&mut config, "typeAssertion.spaceBeforeExpression", true, &mut diagnostics),
-        type_literal_space_surrounding_properties: get_value(&mut config, "typeLiteral.spaceSurroundingProperties", true, &mut diagnostics),
+        type_literal_space_surrounding_properties: get_value(&mut config, "typeLiteral.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),
         while_statement_space_after_while_keyword: get_value(&mut config, "whileStatement.spaceAfterWhileKeyword", true, &mut diagnostics),
     };
 

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -532,6 +532,8 @@ pub struct Configuration {
     pub object_pattern_space_surrounding_properties: bool,
     #[serde(rename = "setAccessor.spaceBeforeParentheses")]
     pub set_accessor_space_before_parentheses: bool,
+    #[serde(rename = "spaceSurroundingProperties")]
+    pub space_surrounding_properties: bool,
     #[serde(rename = "taggedTemplate.spaceBeforeLiteral")]
     pub tagged_template_space_before_literal: bool,
     #[serde(rename = "typeAnnotation.spaceBeforeColon")]

--- a/tests/specs/general/SpaceSurroundingProperties_False.txt
+++ b/tests/specs/general/SpaceSurroundingProperties_False.txt
@@ -1,0 +1,10 @@
+~~ spaceSurroundingProperties: false ~~
+== should format ==
+const obj = { key: value };
+const { key: value } = obj;
+let value: { key: Type };
+
+[expect]
+const obj = {key: value};
+const {key: value} = obj;
+let value: {key: Type};


### PR DESCRIPTION
This controls the default values of `objectExpression.spaceSurroundingProperties`, `objectPattern.spaceSurroundingProperties`, and `typeLiteral.spaceSurroundingProperties` (#114).