### PR TITLE
chore: Upgrade swc_ecmascript to 0.39.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tracing = ["dprint-core/tracing"]
 dprint-core = { version = "0.42.0", features = ["formatting"] }
 fnv = "1.0.7"
 swc_common = "0.10.20"
-swc_ecmascript = { version = "0.36.0", features = ["parser"] }
+swc_ecmascript = { version = "0.39.0", features = ["parser"] }
 swc_ast_view = { version = "0.20.0", package = "dprint-swc-ecma-ast-view" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ dprint-core = { version = "0.42.0", features = ["formatting"] }
 fnv = "1.0.7"
 swc_common = "0.10.20"
 swc_ecmascript = { version = "0.39.0", features = ["parser"] }
-swc_ast_view = { version = "0.20.0", package = "dprint-swc-ecma-ast-view" }
+swc_ast_view = { version = "0.21.0", package = "dprint-swc-ecma-ast-view" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 


### PR DESCRIPTION
~~It's necessary to upgrade `dprint-swc-ecma-ast-view` as well, blocked by https://github.com/dprint/dprint-swc-ecma-ast-view/pull/24~~
now all ready!