### PR TITLE
jsx: add spaceBeforeSelfClosingTagSlash config

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -331,6 +331,14 @@ impl ConfigurationBuilder {
         self.insert("jsxExpressionContainer.spaceSurroundingExpression", value.into())
     }
 
+    /// Whether to add a space before the end of a self closing tag of a JSX element.
+    ///
+    /// * `true` (default) - Ex. `<Test />`
+    /// * `false` - Ex. `<Test/>`
+    pub fn jsx_element_space_before_self_closing_tag(&mut self, value: bool) -> &mut Self {
+        self.insert("jsxElement.spaceBeforeSelfClosingTag", value.into())
+    }
+
     /// Whether to add a space surrounding the properties of an object expression.
     ///
     /// * `true` (default) - Ex. `{ key: value }`
@@ -1073,6 +1081,7 @@ mod tests {
             .if_statement_space_after_if_keyword(true)
             .import_declaration_space_surrounding_named_imports(true)
             .jsx_expression_container_space_surrounding_expression(true)
+            .jsx_element_space_before_self_closing_tag(true)
             .method_space_before_parentheses(true)
             .object_expression_space_surrounding_properties(false)
             .object_pattern_space_surrounding_properties(false)
@@ -1085,7 +1094,7 @@ mod tests {
             .while_statement_space_after_while_keyword(true);
 
         let inner_config = config.get_inner_config();
-        assert_eq!(inner_config.len(), 151);
+        assert_eq!(inner_config.len(), 152);
         let diagnostics = resolve_config(inner_config, &resolve_global_config(HashMap::new()).config).diagnostics;
         assert_eq!(diagnostics.len(), 0);
     }

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -331,12 +331,12 @@ impl ConfigurationBuilder {
         self.insert("jsxExpressionContainer.spaceSurroundingExpression", value.into())
     }
 
-    /// Whether to add a space before the end of a self closing tag of a JSX element.
+    /// Whether to add a space before the slash in a self closing tag for a JSX element.
     ///
     /// * `true` (default) - Ex. `<Test />`
     /// * `false` - Ex. `<Test/>`
-    pub fn jsx_element_space_before_self_closing_tag(&mut self, value: bool) -> &mut Self {
-        self.insert("jsxElement.spaceBeforeSelfClosingTag", value.into())
+    pub fn jsx_element_space_before_self_closing_tag_slash(&mut self, value: bool) -> &mut Self {
+        self.insert("jsxElement.spaceBeforeSelfClosingTagSlash", value.into())
     }
 
     /// Whether to add a space surrounding the properties of an object expression.
@@ -1081,7 +1081,7 @@ mod tests {
             .if_statement_space_after_if_keyword(true)
             .import_declaration_space_surrounding_named_imports(true)
             .jsx_expression_container_space_surrounding_expression(true)
-            .jsx_element_space_before_self_closing_tag(true)
+            .jsx_element_space_before_self_closing_tag_slash(true)
             .method_space_before_parentheses(true)
             .object_expression_space_surrounding_properties(false)
             .object_pattern_space_surrounding_properties(false)

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -193,6 +193,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
         if_statement_space_after_if_keyword: get_value(&mut config, "ifStatement.spaceAfterIfKeyword", true, &mut diagnostics),
         import_declaration_space_surrounding_named_imports: get_value(&mut config, "importDeclaration.spaceSurroundingNamedImports", true, &mut diagnostics),
         jsx_expression_container_space_surrounding_expression: get_value(&mut config, "jsxExpressionContainer.spaceSurroundingExpression", false, &mut diagnostics),
+        jsx_element_space_before_self_closing_tag: get_value(&mut config, "jsxElement.spaceBeforeSelfClosingTag", true, &mut diagnostics),
         method_space_before_parentheses: get_value(&mut config, "method.spaceBeforeParentheses", false, &mut diagnostics),
         object_expression_space_surrounding_properties: get_value(&mut config, "objectExpression.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),
         object_pattern_space_surrounding_properties: get_value(&mut config, "objectPattern.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -193,7 +193,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
         if_statement_space_after_if_keyword: get_value(&mut config, "ifStatement.spaceAfterIfKeyword", true, &mut diagnostics),
         import_declaration_space_surrounding_named_imports: get_value(&mut config, "importDeclaration.spaceSurroundingNamedImports", true, &mut diagnostics),
         jsx_expression_container_space_surrounding_expression: get_value(&mut config, "jsxExpressionContainer.spaceSurroundingExpression", false, &mut diagnostics),
-        jsx_element_space_before_self_closing_tag: get_value(&mut config, "jsxElement.spaceBeforeSelfClosingTag", true, &mut diagnostics),
+        jsx_element_space_before_self_closing_tag_slash: get_value(&mut config, "jsxElement.spaceBeforeSelfClosingTagSlash", true, &mut diagnostics),
         method_space_before_parentheses: get_value(&mut config, "method.spaceBeforeParentheses", false, &mut diagnostics),
         object_expression_space_surrounding_properties: get_value(&mut config, "objectExpression.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),
         object_pattern_space_surrounding_properties: get_value(&mut config, "objectPattern.spaceSurroundingProperties", space_surrounding_properties, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -556,8 +556,8 @@ pub struct Configuration {
     pub import_declaration_space_surrounding_named_imports: bool,
     #[serde(rename = "jsxExpressionContainer.spaceSurroundingExpression")]
     pub jsx_expression_container_space_surrounding_expression: bool,
-    #[serde(rename = "jsxElement.spaceBeforeSelfClosingTag")]
-    pub jsx_element_space_before_self_closing_tag: bool,
+    #[serde(rename = "jsxElement.spaceBeforeSelfClosingTagSlash")]
+    pub jsx_element_space_before_self_closing_tag_slash: bool,
     #[serde(rename = "method.spaceBeforeParentheses")]
     pub method_space_before_parentheses: bool,
     #[serde(rename = "objectExpression.spaceSurroundingProperties")]

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -556,6 +556,8 @@ pub struct Configuration {
     pub import_declaration_space_surrounding_named_imports: bool,
     #[serde(rename = "jsxExpressionContainer.spaceSurroundingExpression")]
     pub jsx_expression_container_space_surrounding_expression: bool,
+    #[serde(rename = "jsxElement.spaceBeforeSelfClosingTag")]
+    pub jsx_element_space_before_self_closing_tag: bool,
     #[serde(rename = "method.spaceBeforeParentheses")]
     pub method_space_before_parentheses: bool,
     #[serde(rename = "objectExpression.spaceSurroundingProperties")]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2746,6 +2746,7 @@ fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Cont
 }
 
 fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItems {
+    let space_before_self_closing_tag = context.config.jsx_element_space_before_self_closing_tag;
     let force_use_new_lines = get_force_is_multi_line(node, context);
     let start_info = Info::new("openingElementStartInfo");
     let mut items = PrintItems::new();
@@ -2765,7 +2766,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
             allow_blank_lines: false,
             separator: Separator::none(),
             single_line_space_at_start: true,
-            single_line_space_at_end: node.self_closing(),
+            single_line_space_at_end: node.self_closing() && space_before_self_closing_tag,
             custom_single_line_separator: None,
             multi_line_options: parser_helpers::MultiLineOptions::surround_newlines_indented(),
             force_possible_newline_at_start: false,
@@ -2787,7 +2788,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
     }
 
     if node.self_closing() {
-        if node.attrs.is_empty() {
+        if node.attrs.is_empty() && space_before_self_closing_tag {
             items.push_str(""); // force current line indentation
             items.extend(space_if_not_start_line());
         }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2746,7 +2746,7 @@ fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Cont
 }
 
 fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItems {
-    let space_before_self_closing_tag = context.config.jsx_element_space_before_self_closing_tag;
+    let space_before_self_closing_tag_slash = context.config.jsx_element_space_before_self_closing_tag_slash;
     let force_use_new_lines = get_force_is_multi_line(node, context);
     let start_info = Info::new("openingElementStartInfo");
     let mut items = PrintItems::new();
@@ -2766,7 +2766,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
             allow_blank_lines: false,
             separator: Separator::none(),
             single_line_space_at_start: true,
-            single_line_space_at_end: node.self_closing() && space_before_self_closing_tag,
+            single_line_space_at_end: node.self_closing() && space_before_self_closing_tag_slash,
             custom_single_line_separator: None,
             multi_line_options: parser_helpers::MultiLineOptions::surround_newlines_indented(),
             force_possible_newline_at_start: false,
@@ -2788,7 +2788,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
     }
 
     if node.self_closing() {
-        if node.attrs.is_empty() && space_before_self_closing_tag {
+        if node.attrs.is_empty() && space_before_self_closing_tag_slash {
             items.push_str(""); // force current line indentation
             items.extend(space_if_not_start_line());
         }

--- a/tests/specs/jsx/JsxElement/JsxElement_SpaceBeforeSelfClosingTagSlash_False.txt
+++ b/tests/specs/jsx/JsxElement/JsxElement_SpaceBeforeSelfClosingTagSlash_False.txt
@@ -1,5 +1,5 @@
 -- filePath: file.tsx --
-~~ jsxElement.spaceBeforeSelfClosingTag: false ~~
+~~ jsxElement.spaceBeforeSelfClosingTagSlash: false ~~
 == should avoid space before self closing tag when there are no attributes ==
 const t = <Test />;
 

--- a/tests/specs/jsx/JsxElement/JsxElement_SpaceBeforeSelfClosingTag_False.txt
+++ b/tests/specs/jsx/JsxElement/JsxElement_SpaceBeforeSelfClosingTag_False.txt
@@ -1,0 +1,13 @@
+-- filePath: file.tsx --
+~~ jsxElement.spaceBeforeSelfClosingTag: false ~~
+== should avoid space before self closing tag when there are no attributes ==
+const t = <Test />;
+
+[expect]
+const t = <Test/>;
+
+== should avoid space before self closing tag when there are attributes =
+const t = <Test first="foo" second="bar" />;
+
+[expect]
+const t = <Test first="foo" second="bar"/>;


### PR DESCRIPTION
This PR adds a new configuration option, `jsxElement.spaceBeforeSelfClosingTag`, that controls whether or not a space is inserted before the end of the self closing tag of a JSX element. 

`true`:
```jsx
<Test />
```

`false`:
```jsx
<Test/>
```