### PR TITLE
statements: allow sorting import and export fully alphabetically

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -460,11 +460,29 @@ impl ConfigurationBuilder {
         self.insert("module.sortImportDeclarations", value.to_string().into())
     }
 
+    /// Specifies the sorting order of import declarations between directories and files within the
+    /// same parent directory.
+    ///
+    /// * `foldersFirst` (default) - Sorts folders first, before files
+    /// * `alphabetical` - Sorts folders and files together, alphabetically, regardless of type
+    pub fn module_folder_sort_order_import_declarations(&mut self, value: FolderSortOrder) -> &mut Self {
+        self.insert("module.folderSortOrderImportDeclarations", value.to_string().into())
+    }
+
     /// Alphabetically sorts the export declarations based on their module specifiers.
     ///
     /// Default: Case insensitive
     pub fn module_sort_export_declarations(&mut self, value: SortOrder) -> &mut Self {
         self.insert("module.sortExportDeclarations", value.to_string().into())
+    }
+
+    /// Specifies the sorting order of export declarations between directories and files within the
+    /// same parent directory.
+    ///
+    /// * `foldersFirst` (default) - Sorts folders first, before files
+    /// * `alphabetical` - Sorts folders and files together, alphabetically, regardless of type
+    pub fn module_folder_sort_order_export_declarations(&mut self, value: FolderSortOrder) -> &mut Self {
+        self.insert("module.folderSortOrderExportDeclarations", value.to_string().into())
     }
 
     /// Alphabetically sorts the import declaration's named imports.
@@ -943,7 +961,9 @@ mod tests {
             .type_literal_separator_kind_multi_line(SemiColonOrComma::Comma)
             /* sorting */
             .module_sort_import_declarations(SortOrder::Maintain)
+            .module_folder_sort_order_import_declarations(FolderSortOrder::FoldersFirst)
             .module_sort_export_declarations(SortOrder::Maintain)
+            .module_folder_sort_order_export_declarations(FolderSortOrder::FoldersFirst)
             .import_declaration_sort_named_imports(SortOrder::Maintain)
             .export_declaration_sort_named_exports(SortOrder::Maintain)
             /* ignore comments */
@@ -1085,7 +1105,7 @@ mod tests {
             .while_statement_space_after_while_keyword(true);
 
         let inner_config = config.get_inner_config();
-        assert_eq!(inner_config.len(), 151);
+        assert_eq!(inner_config.len(), 153);
         let diagnostics = resolve_config(inner_config, &resolve_global_config(HashMap::new()).config).diagnostics;
         assert_eq!(diagnostics.len(), 0);
     }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -63,7 +63,9 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
         type_literal_separator_kind_multi_line: get_value(&mut config, "typeLiteral.separatorKind.multiLine", type_literal_separator_kind, &mut diagnostics),
         /* sorting */
         module_sort_import_declarations: get_value(&mut config, "module.sortImportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),
+        module_folder_sort_order_import_declarations: get_value(&mut config, "module.folderSortOrderImportDeclarations", FolderSortOrder::FoldersFirst, &mut diagnostics),
         module_sort_export_declarations: get_value(&mut config, "module.sortExportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),
+        module_folder_sort_order_export_declarations: get_value(&mut config, "module.folderSortOrderExportDeclarations", FolderSortOrder::FoldersFirst, &mut diagnostics),
         import_declaration_sort_named_imports: get_value(&mut config, "importDeclaration.sortNamedImports", SortOrder::CaseInsensitive, &mut diagnostics),
         export_declaration_sort_named_exports: get_value(&mut config, "exportDeclaration.sortNamedExports", SortOrder::CaseInsensitive, &mut diagnostics),
         /* ignore comments */

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -280,6 +280,21 @@ generate_str_to_from![
     [CaseInsensitive, "caseInsensitive"]
 ];
 
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FolderSortOrder {
+  /// Sort folders first before files
+  FoldersFirst,
+  /// Sort purely alphabetically regardless of type
+  Alphabetical,
+}
+
+generate_str_to_from![
+  FolderSortOrder,
+    [FoldersFirst, "foldersFirst"],
+    [Alphabetical, "alphabetical"]
+];
+
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Configuration {
@@ -307,8 +322,12 @@ pub struct Configuration {
     /* sorting */
     #[serde(rename = "module.sortImportDeclarations")]
     pub module_sort_import_declarations: SortOrder,
+    #[serde(rename = "module.folderSortOrderImportDeclarations")]
+    pub module_folder_sort_order_import_declarations: FolderSortOrder,
     #[serde(rename = "module.sortExportDeclarations")]
     pub module_sort_export_declarations: SortOrder,
+    #[serde(rename = "module.folderSortOrderExportDeclarations")]
+    pub module_folder_sort_order_export_declarations: FolderSortOrder,
     #[serde(rename = "importDeclaration.sortNamedImports")]
     pub import_declaration_sort_named_imports: SortOrder,
     #[serde(rename = "exportDeclaration.sortNamedExports")]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1254,8 +1254,9 @@ fn parse_named_import_or_export_specifiers<'a>(parent: Node<'a>, specifiers: Vec
         context: &Context<'a>,
     ) -> Option<Box<dyn Fn((usize, Option<&Node<'a>>), (usize, Option<&Node<'a>>), &Module<'a>) -> std::cmp::Ordering>> {
         match parent_decl {
-            Node::NamedExport(_) => get_node_sorter_from_order(context.config.export_declaration_sort_named_exports),
-            Node::ImportDecl(_) => get_node_sorter_from_order(context.config.import_declaration_sort_named_imports),
+            // Named imports / exports don't have folders in the node list, so just use Alphabetical
+            Node::NamedExport(_) => get_node_sorter_from_order(context.config.export_declaration_sort_named_exports, FolderSortOrder::Alphabetical),
+            Node::ImportDecl(_) => get_node_sorter_from_order(context.config.import_declaration_sort_named_imports, FolderSortOrder::Alphabetical),
             _ => unreachable!(),
         }
     }
@@ -5245,8 +5246,8 @@ fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Co
         context: &Context<'a>,
     ) -> Option<Box<dyn Fn((usize, Option<&Node<'a>>), (usize, Option<&Node<'a>>), &Module<'a>) -> std::cmp::Ordering>> {
         match group_kind {
-            StmtGroupKind::Imports => get_node_sorter_from_order(context.config.module_sort_import_declarations),
-            StmtGroupKind::Exports => get_node_sorter_from_order(context.config.module_sort_export_declarations),
+            StmtGroupKind::Imports => get_node_sorter_from_order(context.config.module_sort_import_declarations, context.config.module_folder_sort_order_import_declarations),
+            StmtGroupKind::Exports => get_node_sorter_from_order(context.config.module_sort_export_declarations, context.config.module_folder_sort_order_export_declarations),
             StmtGroupKind::Other => None,
         }
     }

--- a/src/parsing/sorting/mod.rs
+++ b/src/parsing/sorting/mod.rs
@@ -9,13 +9,13 @@ use crate::configuration::*;
 
 // a little rough, but good enough for our purposes
 
-pub fn get_node_sorter_from_order<'a>(order: SortOrder) -> Option<Box<dyn Fn((usize, Option<&Node<'a>>), (usize, Option<&Node<'a>>), &Module<'a>) -> Ordering>> {
+pub fn get_node_sorter_from_order<'a>(order: SortOrder, folder_sort_order: FolderSortOrder) -> Option<Box<dyn Fn((usize, Option<&Node<'a>>), (usize, Option<&Node<'a>>), &Module<'a>) -> Ordering>> {
     // todo: how to reduce code duplication here?
     match order {
         SortOrder::Maintain => None,
-        SortOrder::CaseInsensitive => Some(Box::new(|(a_index, a), (b_index, b), module| {
+        SortOrder::CaseInsensitive => Some(Box::new(move |(a_index, a), (b_index, b), module| {
             let result = if is_import_or_export_declaration(&a) {
-                cmp_optional_nodes(a, b, module, |a, b, module| cmp_module_specifiers(a.text_fast(module), b.text_fast(module), cmp_text_case_insensitive))
+                cmp_optional_nodes(a, b, module, |a, b, module| cmp_module_specifiers(a.text_fast(module), b.text_fast(module), folder_sort_order, cmp_text_case_insensitive))
             } else {
                 cmp_optional_nodes(a, b, module, |a, b, module| cmp_text_case_insensitive(a.text_fast(module), b.text_fast(module)))
             };
@@ -25,9 +25,9 @@ pub fn get_node_sorter_from_order<'a>(order: SortOrder) -> Option<Box<dyn Fn((us
                 result
             }
         })),
-        SortOrder::CaseSensitive => Some(Box::new(|(a_index, a), (b_index, b), module| {
+        SortOrder::CaseSensitive => Some(Box::new(move |(a_index, a), (b_index, b), module| {
             let result = if is_import_or_export_declaration(&a) {
-                cmp_optional_nodes(a, b, module, |a, b, module| cmp_module_specifiers(a.text_fast(module), b.text_fast(module), cmp_text_case_sensitive))
+                cmp_optional_nodes(a, b, module, |a, b, module| cmp_module_specifiers(a.text_fast(module), b.text_fast(module), folder_sort_order, cmp_text_case_sensitive))
             } else {
                 cmp_optional_nodes(a, b, module, |a, b, module| cmp_text_case_sensitive(a.text_fast(module), b.text_fast(module)))
             };

--- a/src/parsing/sorting/module_specifiers.rs
+++ b/src/parsing/sorting/module_specifiers.rs
@@ -28,12 +28,12 @@ pub fn cmp_module_specifiers(a: &str, b: &str, folder_sort_order: FolderSortOrde
     };
 
     fn compare_folder_items(a_info: &ModuleSpecifierInfo, b_info: &ModuleSpecifierInfo, folder_sort_order: FolderSortOrder, cmp_text: impl Fn(&str, &str) -> Ordering) -> Ordering {
-        let path_length_ordering = a_info.folder_items.len().cmp(&b_info.folder_items.len()).reverse();
+        let path_length_ordering = b_info.folder_items.len().cmp(&a_info.folder_items.len());
         let alphabetical_ordering = a_info.folder_items.iter()
             .zip(b_info.folder_items.iter())
             .map(|(a, b)| cmp_text(a, b))
             .find(|ordering| *ordering != Ordering::Equal)
-            .unwrap_or(path_length_ordering);
+            .unwrap_or(path_length_ordering.reverse());
         match (folder_sort_order, path_length_ordering) {
             (FolderSortOrder::FoldersFirst, Ordering::Equal) => alphabetical_ordering,
             (FolderSortOrder::FoldersFirst, _) => path_length_ordering,

--- a/tests/specs/file/sorting/a/Statements_FolderSortOrderImportDeclarations_Alphabetical.txt
+++ b/tests/specs/file/sorting/a/Statements_FolderSortOrderImportDeclarations_Alphabetical.txt
@@ -1,0 +1,10 @@
+~~ module.sortImportDeclarations: caseInsensitive, module.folderSortOrderImportDeclarations: alphabetical ~~
+== should sort import declarations purely alphabetically ==
+import {} from "s/d/t/f"
+import type {} from "s/d/m";
+import {} from "s/d/m";
+
+[expect]
+import type {} from "s/d/m";
+import {} from "s/d/m";
+import {} from "s/d/t/f";

--- a/tests/specs/file/sorting/a/Statements_FolderSortOrderImportDeclarations_Alphabetical.txt
+++ b/tests/specs/file/sorting/a/Statements_FolderSortOrderImportDeclarations_Alphabetical.txt
@@ -4,7 +4,19 @@ import {} from "s/d/t/f"
 import type {} from "s/d/m";
 import {} from "s/d/m";
 
+import { _2 } from "../../a/b";
+import { _1 } from "../../a";
+import { _4 } from "../d/e";
+import { _5 } from "../d/f";
+import { _3 } from "../c";
+
 [expect]
 import type {} from "s/d/m";
 import {} from "s/d/m";
 import {} from "s/d/t/f";
+
+import { _1 } from "../../a";
+import { _2 } from "../../a/b";
+import { _3 } from "../c";
+import { _4 } from "../d/e";
+import { _5 } from "../d/f";


### PR DESCRIPTION
It's a little out of date due to the recent import sorting changes that you made upstream, but here's what we had on our fork previously.