### PR TITLE
Fix issue where jsx line breaks were not respecting quote config.

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -7941,11 +7941,19 @@ fn jsx_space_separator(previous_node: &Node, current_node: &Node, context: &Cont
     }
   }
 
+  fn get_quote_char(context: &Context) -> String {
+    let char = match context.config.quote_style {
+      QuoteStyle::PreferDouble | QuoteStyle::AlwaysDouble => "\"",
+      QuoteStyle::PreferSingle | QuoteStyle::AlwaysSingle => "\'"
+    };
+    return format!("{}", char);
+  }
+
   fn jsx_force_space_with_newline_if_either_node_multi_line(previous_node: &Node, current_node: &Node, context: &Context) -> PrintItems {
     let previous_node_info_range = get_node_info_range(previous_node, context);
     let current_node_info_range = get_node_info_range(current_node, context);
     let spaces_between_count = node_helpers::count_spaces_between_jsx_children(previous_node, current_node, &context.module);
-    let jsx_space_expr_text = format!("{{\"{}\"}}", " ".repeat(spaces_between_count));
+    let jsx_space_expr_text = format!("{{{}{}{}}}", get_quote_char(context), " ".repeat(spaces_between_count), get_quote_char(context));
     if_true_or(
       "jsxIsLastChildMultiLine",
       move |condition_context| {
@@ -7992,7 +8000,7 @@ fn jsx_space_separator(previous_node: &Node, current_node: &Node, context: &Cont
 
     if spaces_between_count > 1 {
       items.push_signal(Signal::PossibleNewLine);
-      items.push_string(format!("{{\"{}\"}}", " ".repeat(spaces_between_count)));
+      items.push_string(format!("{{{}{}{}}}", get_quote_char(context), " ".repeat(spaces_between_count), get_quote_char(context)));
       items.push_signal(Signal::PossibleNewLine);
       return items;
     }
@@ -8032,7 +8040,7 @@ fn jsx_space_separator(previous_node: &Node, current_node: &Node, context: &Cont
         true_path: {
           let mut items = PrintItems::new();
           items.push_signal(Signal::PossibleNewLine);
-          items.push_str("{\" \"}");
+          items.push_string(format!("{{{} {}}}", get_quote_char(context), get_quote_char(context)));
           items.push_signal(Signal::NewLine);
           Some(items)
         },

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -7942,11 +7942,10 @@ fn jsx_space_separator(previous_node: &Node, current_node: &Node, context: &Cont
   }
 
   fn get_quote_char(context: &Context) -> String {
-    let char = match context.config.quote_style {
-      QuoteStyle::PreferDouble | QuoteStyle::AlwaysDouble => "\"",
-      QuoteStyle::PreferSingle | QuoteStyle::AlwaysSingle => "\'"
+    return match context.config.quote_style {
+      QuoteStyle::PreferDouble | QuoteStyle::AlwaysDouble => "\"".to_string(),
+      QuoteStyle::PreferSingle | QuoteStyle::AlwaysSingle => "\'".to_string()
     };
-    return format!("{}", char);
   }
 
   fn jsx_force_space_with_newline_if_either_node_multi_line(previous_node: &Node, current_node: &Node, context: &Context) -> PrintItems {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -7944,7 +7944,7 @@ fn jsx_space_separator(previous_node: &Node, current_node: &Node, context: &Cont
   fn get_quote_char(context: &Context) -> String {
     return match context.config.quote_style {
       QuoteStyle::PreferDouble | QuoteStyle::AlwaysDouble => "\"".to_string(),
-      QuoteStyle::PreferSingle | QuoteStyle::AlwaysSingle => "\'".to_string()
+      QuoteStyle::PreferSingle | QuoteStyle::AlwaysSingle => "'".to_string()
     };
   }
 

--- a/tests/specs/literals/StringLiteral/StringLiteral_QuoteStyle_AlwaysSingle_Jsx.txt
+++ b/tests/specs/literals/StringLiteral/StringLiteral_QuoteStyle_AlwaysSingle_Jsx.txt
@@ -5,3 +5,14 @@ const test = <div test="'"></div>;
 
 [expect]
 const test = <div test="'"></div>;
+
+== should use correct quote style when breaking jsx text ==
+const test = <>This is a really long line that should be broken up, with a space: {value} and the space should use the configured quote style</>;
+
+[expect]
+const test = (
+    <>
+        This is a really long line that should be broken up, with a space: {value}{' '}
+        and the space should use the configured quote style
+    </>
+);


### PR DESCRIPTION
The quote characters for jsx line breaks were hard coded to use double quotes. This PR uses the configured QuoteStyle to create the empty string.

Fixes #300 