### PR TITLE
parentheses: don't strip parens around a destructuring assignment

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2390,6 +2390,14 @@ fn should_skip_paren_expr(node: &ParenExpr, context: &Context) -> bool {
     return false;
   }
 
+  // keep parens around any destructuring assignments
+  if let Node::AssignExpr(assign_expr) = node.expr.as_node() {
+    let left_kind = assign_expr.left.kind();
+    if matches!(left_kind, NodeKind::ObjectPat) {
+      return false;
+    }
+  }
+
   if matches!(node.expr.kind(), NodeKind::ArrayLit) {
     return true;
   }

--- a/tests/specs/issues/issue0306.txt
+++ b/tests/specs/issues/issue0306.txt
@@ -1,0 +1,7 @@
+== should not remove parentheses around a destructuring assignment ==
+({ a } = b);
+(a = b);
+
+[expect]
+({ a } = b);
+a = b;


### PR DESCRIPTION
Fixes https://github.com/dprint/dprint-plugin-typescript/issues/306.