### PR TITLE
Cast &last_node to &dyn Spanned

### DIFF
--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -6037,12 +6037,7 @@ fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Co
       let last_comment = comments.iter().filter(|c| !context.has_handled_comment(c)).last().map(|c| c.span);
       items.extend(parse_comments_as_statements(
         comments.into_iter(),
-        if let Some(last_node) = &last_node {
-          // todo: why can't I just use .as_ref() here?
-          Some(last_node)
-        } else {
-          None
-        },
+        last_node.as_ref().map(|x| x as &dyn Spanned),
         context,
       ));
       last_node = last_comment.or(last_node);


### PR DESCRIPTION
This change fixes a todo in the parser, replacing an `if` statement that has an implicit cast to a one-liner and an explicit cast.

The function `parse_comments_as_statements()` expects a `last_node: Option<&dyn Spanned>`. But `last_node.as_ref()` will map an `Option<Span>` to an `Option<&Span>`. IIUC, this results in a compiler error as `&Span` and `&dyn Span` have different memory layouts (`&Span` is a struct that is statically dispatched, and `&dyn Span` is a trait object that is dynamically dispatched) and so are incompatible types.

With the `if` statement before, the compiler does this cast for you implicitly.

cc @declanvong 