### PR TITLE
fix: allow JSX generic trailing comma iff required

### DIFF
--- a/tests/specs/general/Jsx_TrailingCommas.txt
+++ b/tests/specs/general/Jsx_TrailingCommas.txt
@@ -15,6 +15,10 @@ const Test3 = <div></div>;
 function test<T,>() {
 }
 
+// generic constraints are not ambiguous either
+const Test4 = <P extends R<S, T>,>() => {};
+const Test5 = <P extends R<S, T>>() => {};
+
 [expect]
 const Test1 = <T,>() => false;
 const Test2 = function<T,>() {};
@@ -23,3 +27,7 @@ const Test3 = <div></div>;
 // not for declarations though
 function test<T>() {
 }
+
+// generic constraints are not ambiguous either
+const Test4 = <P extends R<S, T>>() => {};
+const Test5 = <P extends R<S, T>>() => {};

--- a/tests/specs/issues/issue0303.txt
+++ b/tests/specs/issues/issue0303.txt
@@ -1,23 +1,24 @@
+-- test.tsx --
 == should format with comments ==
-const t = <X>() => (
+const t = <X,>() => (
     <>
         {/* Comment 1 */}
         {/* Comment 2 */}
         {/* Comment 3 */}
     </>
 );
-const u = <X>() => {
+const u = <X,>() => {
     // Hello world
 };
 
 [expect]
-const t = <X>() => (
+const t = <X,>() => (
     <>
         {/* Comment 1 */}
         {/* Comment 2 */}
         {/* Comment 3 */}
     </>
 );
-const u = <X>() => {
+const u = <X,>() => {
     // Hello world
 };


### PR DESCRIPTION
This changes the JSX type parameter trailing comma logic to only allow a trailing comma if there is only one type parameter which is an identifier. The ambiguity only exists in this specific scenario.

This fixes a bug where a function expression with a generic constraint with type arguments would cause a trailing comma to be added.

This also fixes the test for #303 which ironically also included this ambiguity. swc manages to parse it (without fixing the input) but tsc and VSCode do not, so I have erred on the side adding the comma to the inputs too.