### PR TITLE
fix: fail to build with features=tracing

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -72,7 +72,7 @@ fn inner_format(parsed_source: &ParsedSource, config: &Configuration) -> Result<
 #[cfg(feature = "tracing")]
 pub fn trace_file(file_path: &Path, file_text: &str, config: &Configuration) -> dprint_core::formatting::TracingResult {
   let parsed_source = parse_swc_ast(file_path, file_text).unwrap();
-  ensure_no_specific_syntax_errors(parsed_source).unwrap();
+  ensure_no_specific_syntax_errors(&parsed_source).unwrap();
   dprint_core::formatting::trace_printing(|| parse(&parsed_source, config), config_to_print_options(file_text, config))
 }
 


### PR DESCRIPTION
This change fixes a type error that occurs when building with the `tracing` feature. It looks like it may have been introduced in 932351a6f6cad4e19d54f04db63e5b5b5b3315a1.

```
$ cargo c --features=tracing
    Checking dprint-plugin-typescript v0.58.0
error[E0308]: mismatched types
  --> src/format_text.rs:75:36
   |
75 |   ensure_no_specific_syntax_errors(parsed_source).unwrap();
   |                                    ^^^^^^^^^^^^^
   |                                    |
   |                                    expected `&ParsedSource`, found struct `ParsedSource`
   |                                    help: consider borrowing here: `&parsed_source`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `dprint-plugin-typescript` due to previous error
```