### PR TITLE
array expr: add missing comment check for multiline

### DIFF
--- a/dprint
+++ b/dprint
@@ -1,0 +1,1 @@
+/Users/declan/dprint

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -5994,8 +5994,11 @@ fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mu
   return items;
 
   fn get_force_use_new_lines(node: &dyn Spanned, nodes: &[NodeOrSeparator], prefer_single_line: bool, context: &mut Context) -> bool {
-    if prefer_single_line || nodes.is_empty() {
+    if nodes.is_empty() {
       false
+    } else if prefer_single_line {
+      // if any comments exist on separate lines, then everything becomes multi-line
+      has_any_node_comment_on_different_line(nodes, context)
     } else {
       let open_bracket_token = node
         .tokens_fast(context.program)

--- a/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferSingleLine_True.txt
+++ b/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferSingleLine_True.txt
@@ -13,10 +13,24 @@ const t = [5, 6];
 const t = [5, // testing
     6];
 
+const a = [
+["123456", "123456"], //
+["123456", "123456"], //
+["123456", "123456"], //
+["123456", "123456"], //
+];
+
 [expect]
 const t = [
     5, // testing
     6,
+];
+
+const a = [
+    ["123456", "123456"], //
+    ["123456", "123456"], //
+    ["123456", "123456"], //
+    ["123456", "123456"], //
 ];
 
 == should not be multi line if the objects are allowed to be inline multi-line ==


### PR DESCRIPTION
Adds a missing check for multiline comments to the `force_use_new_lines` for array expressions when using `preferSingleLine. It's in all of the other list-like expressions, so I guess it was just missed here.

Input:
```
const a = [
    ["123456", "123456"], //
    ["123456", "123456"], //
    ["123456", "123456"], //
    ["123456", "123456"], //
];
```

Expected:
```
const a = [
    ["123456", "123456"], //
    ["123456", "123456"], //
    ["123456", "123456"], //
    ["123456", "123456"], //
];
```

Output:
```
const a = [["123456", "123456"], //
["123456", "123456"], //
["123456", "123456"], //
["123456", "123456"] //
];
```

Playground link: [here](https://dprint.dev/playground/#code/MYewdgzgLgBAhjAvDA2gKBp1AiAjAJgGYAWAVgDZsAaGPIsygXRoHoWMsU6SLraCeTVuyw4BDPtwnMYbDpi7jeNKbxlzGAbjRA/config/N4KABGBEA2CWB2BTA6rAJgFwBaQFxgBYAGAGnCgTUXg1Ux3wLIkgFcBnRAFQEMAjdnjAAzHtE7MonALawAwgHtoC+IPyQADgCdEwxFsiTIAR1YKMiAMoYAntERDIYgO48b7ACILWfe4fKQSM4AMgiIANKUjtDC-iwciABCWjwAxohqUM5Y1ABy5pYIAOb2oUhxUHwp6QAKCuywGLAqjuw80ohliACq8Pbs7AASPPBFxRWQDaP2iQpoNnUNTS3q0jwIGOvwE0gAHhiKNFpKAGLKzouNzdvqexhdExgpsHCjitJrmZAq0DYAsqxoE0HkYFBp9DwMAotJdljcoHcQQFtLp9MNRuN8KJxIgjCi9FpCtNOmEhE9WLiAjwtMdnCdWPBUnCAHQJGrU6jYDIZRxrDZbCZ8BDUmwAUV2KIG12Zr0QNX04slDRWIjEEgCACt2LtmaZzFZbH51Pj9F4fH4jFqddJAcCwuydKpHCaDEYOtI+AqJTopSoZfavUrrkJseqWLZwaELCloMzOBpqZDoZF4GhWohZIplNsjNRWNIPIhUtBEyz3Z7CQnUpioHyaAKjOwq1ZWDTvKnijVjuCtE0efhyZSWAo+BqixhFT7lfA483LK3jgy0J3u-o+5lB6DR+P2RhozOm2kW22lyuwWvYP2wJuAhGSdGxLOj-OTx3Rl3z73LxutBSjEL4BFScMmnJ90hfRc3yKRJGmcWBOAAQVTBCtEaLAOiaVIAHkeyTAwB1-IcoFSBQPk5LpmWEaFwObBDhGjSwS3YHIfz-AISNUckmWhMCkl0aE5Q5GgWKvUMiMgDj2C4qEtC4GxwV4ujo1yRBnHCRAbGcaE0yxNVxMk6TCiKQCMFbRBFPo-QVLUjStK0HTVRxIw0AUZAsBeA1IQzTkLOjNyPPUzTtLJQjcwlaEMELYtS2lQ9wIXdtl1GXJ2kQNBFQi1jxKorQAEl4GsLyOhoXz9BOZNbOCgi2JYHKsOEQqLGKjBSq0cqtECuyHJvWroUa7ySrixAlLKiqgvskKaqgHL+ua1rLAzeQlBULKjGEBkmWuKKSxSFkhsSfidAdTkRMyMS1o2uFgN9A9mwOnLBMdLlODOvSLsZK7vRA2LaMstrLuuTqqscsMoCKRAMAQ1J0gGHj9sOx6Tu5V6nICWAGs2JqfKGka8uEIGJuq8TYGkDQIu2mK-SGiDEuKFKOjQXLScyybxKtUV7Dm+GHoWmI5GUKYil4IpGJ4ZjWctbVrunQ5NjCLReJp09Rml4NdNRlgMKwOZePugTjuE5GQzegJOEh6GQLhu6EYN57RJN8MeCKcG0C4DMNBLCxdYRqMIWgCXb3k4b4HgcxIR+o89Z0LMVXOwPwQQgYLyp62HtVlUeqydz7Fm7Hfr87OIkqwnr1CtHjIE-IqHeZq3f2Rw0G0DYAFpYArnQJjb0OdBODya85OuMAbpuaFb9vEGb4QPMgEAAF8QCAA/language/typescript)