### PR TITLE
Add ability to place JSX content at new line

### DIFF
--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -78,6 +78,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     binary_expression_line_per_expression: get_value(&mut config, "binaryExpression.linePerExpression", false, &mut diagnostics),
     jsx_quote_style: get_value(&mut config, "jsx.quoteStyle", quote_style.to_jsx_quote_style(), &mut diagnostics),
     jsx_multi_line_parens: get_value(&mut config, "jsx.multiLineParens", JsxMultiLineParens::Prefer, &mut diagnostics),
+    jsx_force_content_new_line: get_value(&mut config, "jsx.forceContentNewLine", false, &mut diagnostics),
     member_expression_line_per_expression: get_value(&mut config, "memberExpression.linePerExpression", false, &mut diagnostics),
     type_literal_separator_kind_single_line: get_value(
       &mut config,

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -271,6 +271,8 @@ pub struct Configuration {
   pub jsx_quote_style: JsxQuoteStyle,
   #[serde(rename = "jsx.multiLineParens")]
   pub jsx_multi_line_parens: JsxMultiLineParens,
+  #[serde(rename = "jsx.forceContentNewLine")]
+  pub jsx_force_content_new_line: bool,
   #[serde(rename = "memberExpression.linePerExpression")]
   pub member_expression_line_per_expression: bool,
   #[serde(rename = "typeLiteral.separatorKind.singleLine")]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -7801,6 +7801,10 @@ fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOpt
   return ParseJsxWithOpeningAndClosingResult { items, start_info, end_info };
 
   fn get_force_use_multi_lines(opening_element: &Node, children: &[Node], context: &mut Context) -> bool {
+    if context.config.jsx_force_content_new_line {
+      return true;
+    }
+
     // if any of the children are a jsx element or jsx fragment, then force multi-line
     for child in children {
       if matches!(child, Node::JSXElement(_) | Node::JSXFragment(_)) {


### PR DESCRIPTION
This change adds ability to place JSX content at new line.

Option:
```ts
'jsx.forceContentNewLine': true
```

Input:
```jsx
<>
  <Test>{myAwesomeContent}</Test>

  <Test foo={'bar'} bar={'baz'}>{myAwesomeContent}</Test>
</>
```

Output:
```jsx
<>
    <Test>
        {myAwesomeContent}
    </Test>

    <Test foo={"bar"} bar={"baz"}>
        {myAwesomeContent}
    </Test>
</>;
```