### PR TITLE
fix: do not add spaces with zero arguments

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -6511,15 +6511,18 @@ where
   let custom_close_paren = opts.custom_close_paren;
   let first_member_span = opts.nodes.iter().map(|n| n.span()).next();
   let nodes = opts.nodes;
+  let nodes_length = nodes.len();
   let prefer_hanging = if is_parameters {
     context.config.parameters_prefer_hanging
   } else {
     context.config.arguments_prefer_hanging
   };
-  let space_around = if is_parameters {
+  let space_around = if nodes_length > 0 && is_parameters {
     context.config.parameters_space_around
-  } else {
+  } else if nodes_length > 0 {
     context.config.arguments_space_around
+  } else {
+    false
   };
   let trailing_commas = get_trailing_commas(&opts.node, &nodes, is_parameters, context);
 

--- a/tests/specs/general/Arguments_SpaceAround_True.txt
+++ b/tests/specs/general/Arguments_SpaceAround_True.txt
@@ -20,3 +20,11 @@ testing(
     123456,
     123456,
 );
+
+== should not add spaces on empty arguments ==
+testing()
+testing() === true;
+
+[expect]
+testing();
+testing() === true;


### PR DESCRIPTION
The new `spaceAround` option ([added by](https://github.com/dprint/dprint-plugin-typescript/pull/341) @casieber) is excellent, but it is adding unnecessary spaces when functions don't have arguments:

```js
const a = testing()
if (testing() === true) {
    // ...
};

// Generates
const a = testing(  );
if ( testing(  ) === true ) {
    // ...
};

// Instead of
const a = testing();
if ( testing() === true ) {
    // ...
};
```

_[Playground](https://dprint.dev/playground/#code/MYewdgzgLgBAhjAvDKBTaBLMBzAFASgCgMAzGXNTHApRZKAJwFdV8YBvQmbmAel5gA6YYQC+AbiA/config/N4KABGBEA2CWB2BTA6rAJgFwBaQFxgA4AGAGnCgTUXg1Ux3wBYyJIBXAZ0QBUBDAIw54wAM17QuLKFwC2sAMIB7aIvhD8kAA4AnRCMTbIUyAEc2ijIgDKGAJ7REwyOIDuvWxwAiitvwdHyU3NLAAVtRU11KB1ELm0AN0djJBcAGQREAGlKJ2gRANZORAAhbV4AY1inFyxqADkLKwQAcwd0pAKofjLKkMUOWAxYVScOXhlEdsQAVXgHDg4ACV54ZpbOyAHVh2LFNFs+gaGRjRleBAxz+A2kAA8MJRpw6AAxFRdDweHrjTuMKY2GDKsDgqyUMjOUUgqmgtgAsmxoEMAcYIgZeBhFNpPscflA-ijAjF9Nplqt1vgxBJEMZiQYmttJhlhFTJIFeNpwi4Xmx4OVcQA6IohDnUbCxKqnK6XBAbfgIDm2ACitxiC2+AtBiBCBhVaoGJ1E4jZrAAVhxbgKzBZrHZ-Bo6dpvL5-MZzZaZIjkRkRbo1E5HRsJjJ+LrVbp1apNT6w-rvizjTTAnZNEzLGVoAKuJoORisdl4GhRog5EoVNdjNQ2DJPIhytBc4Lg6HtFYc+UKVAzhcrhsOO3EABBcK8ov4IFsJOsfsVaxsTk+QstMJo7RDSVgCdTqCKfimusYPURg3wLMDqzzkdL1Yr1Nr2AbreovcHkUYdOnmeVC8L0fL8J3uuURPsmtipuk6biGes4-leaD-quQHCCBrDyvAipHrEJ7Qd+l6LvBqzFIMLiwFwg6FsOgxYBMQzlAA8neeaGOO2iTsY5SKBCYpTAKIhYt+A6DiI6ZWA2HC1MBrHbpAHFqBO-JYjhJR6Fi2qijQEkbqy0myRw8mYto3BgYgSlCemdSIC4mSILYLhYmORrUuxqh6ax-JNM06EYPOJlfkOwkGBZVk2XZ2gOdpxhoIoyBYCCtoYiWYqmQF2gxXF1m2fZyFSZWqpYhgtb1o2Gp+bB+EtHU4yIGger5ZJbGBHx2gAJLwDYCUTDQyXpi8+YhVlLENawTV0SI7WWJ1GDdQYvXaBloUOShUBNeNiVdX5ZkzX1mVhdlQ3LViq2TdNrYlgoyguXt0kiLy-LfIVDZlIKfnFCpui+mKmlRBFjW3bimGRp+A6vU1al+uKXDfYmxg3Xy-3hlhJWCSlPJw9880DY5JpQM0iAYIO5SVAsikvW9YOfRKUNOYEsBjZcE1JRtKXNSIGO7YN0mwDImj5Q9xVRqVeF-qslUTGgzXc3VV1uhaSoOMdpOg1YiB5PIKhbM0fDNKJvDidLgTugDJ6PDKSDaEpZXC80RvxpS0OBDRWB7EpIOqR9GmUwm1PTnjBNExwJPA2T7sQ1p9usJczS42g3AlpoDaWC7ZMQei0D6xHxnkfAFgYkjs6u7oZaGj9GepoOCwGM9QegzbhpLZANRxUdjPI+maUOGzi05TTnmqQ0VDgpNsf3E4aA6BcAC0sC97oGzT9nugvHFg9isPGCj+PNBTzPiATyIcWQCAAC+IBAA/language/typescript)_

This PR fixes that problem by checking if the number of arguments is zero before adding the spaces.