### PR TITLE
fix: better forcing single line for import and export declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,8 +206,6 @@ dependencies = [
 [[package]]
 name = "dprint-core"
 version = "0.58.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8993a9e868c95a365957c95b7f4db599d10c87389a462ce30f102f2e1e9cec0d"
 dependencies = [
  "anyhow",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-core"
-version = "0.58.1"
+version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4eb65949e6ff07306d8b85f5b95414d6384a0fd5bb130477a9e0f1dbdc17d6"
 dependencies = [
  "anyhow",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = ["dprint-core/tracing"]
 [dependencies]
 anyhow = "1.0.51"
 deno_ast = { version = "0.15.0", features = ["view"] }
-dprint-core = { version = "0.58.1", features = ["formatting"] }
+dprint-core = { path = "../dprint/crates/core", features = ["formatting"] }
 rustc-hash = "1.1.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = ["dprint-core/tracing"]
 [dependencies]
 anyhow = "1.0.51"
 deno_ast = { version = "0.15.0", features = ["view"] }
-dprint-core = { path = "../dprint/crates/core", features = ["formatting"] }
+dprint-core = { version = "0.58.2", features = ["formatting"] }
 rustc-hash = "1.1.0"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }

--- a/tests/specs/declarations/export/ExportDeclaration_ForceSingleLine_True.txt
+++ b/tests/specs/declarations/export/ExportDeclaration_ForceSingleLine_True.txt
@@ -26,3 +26,24 @@ export {
     e, /* and
 not ok */
 } from "./test.ts";
+
+== should collapse a multi-line one ==
+export {
+
+  a,
+
+  b,
+  c,
+  /* testing */
+  d,
+} from "./test.ts";
+export {
+  a,
+  b,
+  c,
+  d,
+} from "./test.ts";
+
+[expect]
+export { a, b, c, /* testing */ d } from "./test.ts";
+export { a, b, c, d } from "./test.ts";

--- a/tests/specs/declarations/import/ImportDeclaration_ForceSingleLine_True.txt
+++ b/tests/specs/declarations/import/ImportDeclaration_ForceSingleLine_True.txt
@@ -26,3 +26,31 @@ import {
     e, /* and
 not ok */
 } from "./test.ts";
+
+== should collapse a multi-line one ==
+import { /* a */
+
+  a,
+
+  /* test */ b, /* other */
+  c,
+  /* testing */
+  d,
+} from "./test.ts"; // actually, a block comment at the start of this line causes a bug
+// where the block comment will not have a space after it. Not worth fixing though
+// because it will be fixed by formatting again (which the CLI does automatically)
+// and it's super rare that someone would put a comment there.
+import {
+  /* a */
+  a,
+  b,
+  c,
+  d,
+} from "./test.ts";
+
+[expect]
+import { /* a */ a, /* test */ b, /* other */ c, /* testing */ d } from "./test.ts"; // actually, a block comment at the start of this line causes a bug
+// where the block comment will not have a space after it. Not worth fixing though
+// because it will be fixed by formatting again (which the CLI does automatically)
+// and it's super rare that someone would put a comment there.
+import { /* a */ a, b, c, d } from "./test.ts";


### PR DESCRIPTION
Amendment to #376.

I need to bump the dprint-core version though.