### PR TITLE
feat: make class prop decorators inline

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -595,7 +595,7 @@ struct GenClassPropCommon<'a> {
 
 fn gen_class_prop_common<'a>(node: GenClassPropCommon<'a>, context: &mut Context<'a>) -> PrintItems {
   let mut items = PrintItems::new();
-  items.extend(gen_decorators(node.decorators, false, context));
+  items.extend(gen_decorators(node.decorators, true, context));
   if node.is_declare {
     items.push_str("declare ");
   }

--- a/tests/specs/declarations/class/property/ClassProperty_All.txt
+++ b/tests/specs/declarations/class/property/ClassProperty_All.txt
@@ -33,8 +33,7 @@ abstract class Test extends Base {
         | number
         | stringg
         | number;
-    @dec
-    readonly propReadonly = 3;
+    @dec readonly propReadonly = 3;
 }
 
 == should wrap an assignment that goes over the line width when sufficient ==


### PR DESCRIPTION
Changes this:

```ts
@$.element()
class Foo extends HTMLElement {
  @$.attr()
  color = 'blue'
  @$.attr()
  another = 123
  @$.attr()
  withCapital = true

  button?: HTMLButtonElement
  result?: number = 123
```

to this:

```ts
@$.element()
class Foo extends HTMLElement {
  @$.attr() color = 'blue'
  @$.attr() another = 123
  @$.attr() withCapital = true

  button?: HTMLButtonElement
  result?: number = 123
```

The tests pass however I'm not 100% confident that it won't produce invalid code in some combination of modifiers or other occassions. We need probably more tests? Should I try and add them?

