### PR TITLE
feat: don't newline in tagged templates

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2620,11 +2620,9 @@ fn gen_tagged_tpl<'a>(node: &'a TaggedTpl, context: &mut Context<'a>) -> PrintIt
 
   let generated_between_comments = gen_comments_between_lines_indented(node.tag.end(), context);
   if generated_between_comments.is_empty() {
-    items.push_condition(conditions::if_above_width_or(
-      context.config.indent_width,
-      if use_space { Signal::SpaceOrNewLine } else { Signal::PossibleNewLine }.into(),
-      if use_space { Signal::SpaceIfNotTrailing.into() } else { PrintItems::new() },
-    ));
+    if use_space {
+      items.push_signal(Signal::SpaceIfNotTrailing);
+    }
   } else {
     items.extend(generated_between_comments);
   }

--- a/tests/specs/expressions/TaggedTemplateExpression/TaggedTemplateExpression_All.txt
+++ b/tests/specs/expressions/TaggedTemplateExpression/TaggedTemplateExpression_All.txt
@@ -20,12 +20,14 @@ const u = tag<
     ThisOutttttt
 >`testing`;
 
-== should move the template literal to the next line when exceeding the width ==
+== should move the template literal to the next line when exceeding the width when has type args ==
 const t = tag<Testing, Other> `testing this out`;
 
 [expect]
-const t = tag<Testing, Other>
-    `testing this out`;
+const t = tag<
+    Testing,
+    Other
+>`testing this out`;
 
 == should not newline if the tagged template tag is below the indent width ==
 tag `ttttttttttttttttttttttttttttttttttt`;

--- a/tests/specs/expressions/TaggedTemplateExpression/TaggedTemplateExpression_SpaceBeforeTemplate_False.txt
+++ b/tests/specs/expressions/TaggedTemplateExpression/TaggedTemplateExpression_SpaceBeforeTemplate_False.txt
@@ -11,12 +11,21 @@ const t = tag<T, U> `testing`;
 [expect]
 const t = tag<T, U>`testing`;
 
-== should move the template literal to the next line when exceeding the width ==
+== should not move the template literal to the next line when exceeding the width ==
+const t = testingtestingtesting`testing this out`;
+
+[expect]
+const t =
+    testingtestingtesting`testing this out`;
+
+== should move the template literal type arguments to the next line when exceeding the width ==
 const t = tag<Testing, Other>`testing this out`;
 
 [expect]
-const t = tag<Testing, Other>
-    `testing this out`;
+const t = tag<
+    Testing,
+    Other
+>`testing this out`;
 
 == should not newline if the tagged template tag is below the indent width ==
 tag `ttttttttttttttttttttttttttttttttttt`;

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_All.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_All.txt
@@ -4,3 +4,19 @@ const t = <test test  = "5" other =  {4}/>
 
 [expect]
 const t = <test test="5" other={4} />;
+
+== should not newline in tagged template ==
+export function Footer() {
+  return (
+    <testing class={someTag`mt-16 flex justify-center items-center flex-col border-none bg-transparent text-black`} />
+  );
+}
+
+[expect]
+export function Footer() {
+    return (
+        <testing
+            class={someTag`mt-16 flex justify-center items-center flex-col border-none bg-transparent text-black`}
+        />
+    );
+}

--- a/tests/specs/literals/TemplateLiteral/TemplateLiteral_All.txt
+++ b/tests/specs/literals/TemplateLiteral/TemplateLiteral_All.txt
@@ -83,12 +83,11 @@ log(myTag `some text`);
 [expect]
 log(myTag`some text`);
 
-== should do a tagged template literal that goes over line width ==
+== should not do a tagged template literal that goes over line width ==
 myCustomTag `testing this out with an str`;
 
 [expect]
-myCustomTag
-    `testing this out with an str`;
+myCustomTag`testing this out with an str`;
 
 == should not do newlines for a member expression ==
 `tttttttttttttest ${testing.this.out.testing}`;


### PR DESCRIPTION
Prettier doesn't newline between a tagged template and a tag. We found this to not be very helpful when using a `tw` tagged template in Deno.