### PR TITLE
fix: maintain param parens in arrow function expr when there's an inner comment

### DIFF
--- a/tests/specs/issues/issue0402.txt
+++ b/tests/specs/issues/issue0402.txt
@@ -1,0 +1,16 @@
+~~ arrowFunction.useParentheses: preferNone ~~
+== should not remove parens for jsdoc type in arrow expr param ==
+process.on("unhandledRejection", (/** @type {any}*/ err) => {
+    if (err) {
+        console.error(err.stack || err.message);
+    }
+    process.exit(1);
+});
+
+[expect]
+process.on("unhandledRejection", (/** @type {any}*/ err) => {
+    if (err) {
+        console.error(err.stack || err.message);
+    }
+    process.exit(1);
+});


### PR DESCRIPTION
Closes #402