### PR TITLE
fix: comments on line above case should not get extra newline when has preceding blank line

### DIFF
--- a/tests/specs/issues/issue0406.txt
+++ b/tests/specs/issues/issue0406.txt
@@ -1,0 +1,21 @@
+== should not add newline after second comment ==
+switch (foo) {
+    // Types
+    case SyntaxKind.A:
+        return 1234;
+
+    // Values
+    case SyntaxKind.B:
+        return 1234;
+}
+
+[expect]
+switch (foo) {
+    // Types
+    case SyntaxKind.A:
+        return 1234;
+
+    // Values
+    case SyntaxKind.B:
+        return 1234;
+}


### PR DESCRIPTION
This is a bit of a hack because I'd rather have the case generate its leading comments that it "owns", but doing so would mean the case comment ownership rules would be spread around in multiple places so this is a lot easier.

Closes #406