### PR TITLE
fix: don't create syntax error with numeric literal as object in member expression

### DIFF
--- a/tests/specs/issues/issue0421.txt
+++ b/tests/specs/issues/issue0421.txt
@@ -1,0 +1,13 @@
+== should add parens for member expr with numeric literal ==
+1+ 2 .toString() +3;
+1+ 2_000 .toString() +3;
+1+ 2..toString() +3;
+1+ 2.1.toString() +3;
+1+ (2).toString() +3;
+
+[expect]
+1 + (2).toString() + 3;
+1 + (2_000).toString() + 3;
+1 + 2..toString() + 3;
+1 + 2.1.toString() + 3;
+1 + (2).toString() + 3;


### PR DESCRIPTION
Closes #421