### PR TITLE
feat: make `jsx.bracketSpacing` high level config

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -793,6 +793,18 @@
     "binaryExpression.linePerExpression": {
       "$ref": "#/definitions/binaryExpression.linePerExpression"
     },
+    "jsx.bracketPosition": {
+      "$ref": "#/definitions/jsx.bracketPosition"
+    },
+    "jsxOpeningElement.bracketPosition": {
+      "$ref": "#/definitions/jsx.bracketPosition"
+    },
+    "jsxSelfClosingElement.bracketPosition": {
+      "$ref": "#/definitions/jsx.bracketPosition"
+    },
+    "jsx.forceNewLinesSurroundingContent": {
+      "$ref": "#/definitions/jsx.forceNewLinesSurroundingContent"
+    },
     "jsx.quoteStyle": {
       "$ref": "#/definitions/jsx.quoteStyle"
     },

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -633,7 +633,7 @@
         "description": "Ex. `import {SomeExport, OtherExport} from \"my-module\";`"
       }]
     },
-    "jsx.spaceBeforeSelfClosingTagSlash": {
+    "jsxSelfClosingElement.spaceBeforeSlash": {
       "description": "Whether to add a space before a JSX element's slash when self closing.",
       "type": "boolean",
       "default": true,
@@ -916,8 +916,8 @@
     "importDeclaration.spaceSurroundingNamedImports": {
       "$ref": "#/definitions/importDeclaration.spaceSurroundingNamedImports"
     },
-    "jsx.spaceBeforeSelfClosingTagSlash": {
-      "$ref": "#/definitions/jsx.spaceBeforeSelfClosingTagSlash"
+    "jsxSelfClosingElement.spaceBeforeSlash": {
+      "$ref": "#/definitions/jsxSelfClosingElement.spaceBeforeSlash"
     },
     "jsxExpressionContainer.spaceSurroundingExpression": {
       "$ref": "#/definitions/jsxExpressionContainer.spaceSurroundingExpression"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -128,12 +128,28 @@ impl ConfigurationBuilder {
     self.insert("jsx.forceNewLinesSurroundingContent", value.into())
   }
 
-  /// If the end angle bracket of a jsx open element or self closing element
+  /// If the end angle bracket of a jsx opening element or self closing element
   /// should be on the same or next line when the attributes span multiple lines.
   ///
   /// Default: `nextLine`
   pub fn jsx_bracket_position(&mut self, value: SameOrNextLinePosition) -> &mut Self {
     self.insert("jsx.bracketPosition", value.to_string().into())
+  }
+
+  /// If the end angle bracket of a jsx opening element should be on the same
+  /// or next line when the attributes span multiple lines.
+  ///
+  /// Default: `nextLine`
+  pub fn jsx_opening_element_bracket_position(&mut self, value: SameOrNextLinePosition) -> &mut Self {
+    self.insert("jsxOpeningElement.bracketPosition", value.to_string().into())
+  }
+
+  /// If the end angle bracket of a jsx self closing element should be on the same
+  /// or next line when the attributes span multiple lines.
+  ///
+  /// Default: `nextLine`
+  pub fn jsx_self_closing_element_bracket_position(&mut self, value: SameOrNextLinePosition) -> &mut Self {
+    self.insert("jsxSelfClosingElement.bracketPosition", value.to_string().into())
   }
 
   /// Whether statements should end in a semi-colon.
@@ -357,8 +373,8 @@ impl ConfigurationBuilder {
   ///
   /// * `true` (default) - Ex. `<Test />`
   /// * `false` - Ex. `<Test/>`
-  pub fn jsx_space_before_self_closing_tag_slash(&mut self, value: bool) -> &mut Self {
-    self.insert("jsx.spaceBeforeSelfClosingTagSlash", value.into())
+  pub fn jsx_self_closing_tag_space_before_slash(&mut self, value: bool) -> &mut Self {
+    self.insert("jsxSelfClosingElement.spaceBeforeSlash", value.into())
   }
 
   /// Whether to add a space surrounding the properties of an object expression.
@@ -1047,6 +1063,8 @@ mod tests {
       .jsx_multi_line_parens(JsxMultiLineParens::Never)
       .jsx_force_new_lines_surrounding_content(true)
       .jsx_bracket_position(SameOrNextLinePosition::Maintain)
+      .jsx_opening_element_bracket_position(SameOrNextLinePosition::Maintain)
+      .jsx_self_closing_element_bracket_position(SameOrNextLinePosition::Maintain)
       .semi_colons(SemiColons::Prefer)
       .brace_position(BracePosition::NextLine)
       .next_control_flow_position(NextControlFlowPosition::SameLine)
@@ -1202,7 +1220,7 @@ mod tests {
       .if_statement_space_after_if_keyword(true)
       .import_declaration_space_surrounding_named_imports(true)
       .jsx_expression_container_space_surrounding_expression(true)
-      .jsx_space_before_self_closing_tag_slash(true)
+      .jsx_self_closing_tag_space_before_slash(true)
       .method_space_before_parentheses(true)
       .object_expression_space_surrounding_properties(false)
       .object_pattern_space_surrounding_properties(false)
@@ -1228,7 +1246,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 173);
+    assert_eq!(inner_config.len(), 175);
     let diagnostics = resolve_config(inner_config, &resolve_global_config(ConfigKeyMap::new(), &Default::default()).config).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -373,7 +373,7 @@ impl ConfigurationBuilder {
   ///
   /// * `true` (default) - Ex. `<Test />`
   /// * `false` - Ex. `<Test/>`
-  pub fn jsx_self_closing_tag_space_before_slash(&mut self, value: bool) -> &mut Self {
+  pub fn jsx_self_closing_element_space_before_slash(&mut self, value: bool) -> &mut Self {
     self.insert("jsxSelfClosingElement.spaceBeforeSlash", value.into())
   }
 
@@ -1220,7 +1220,7 @@ mod tests {
       .if_statement_space_after_if_keyword(true)
       .import_declaration_space_surrounding_named_imports(true)
       .jsx_expression_container_space_surrounding_expression(true)
-      .jsx_self_closing_tag_space_before_slash(true)
+      .jsx_self_closing_element_space_before_slash(true)
       .method_space_before_parentheses(true)
       .object_expression_space_surrounding_properties(false)
       .object_pattern_space_surrounding_properties(false)

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -36,7 +36,13 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
   handle_renamed_config_property(
     &mut config,
     "jsxElement.spaceBeforeSelfClosingTagSlash",
+    "jsxSelfClosingElement.spaceBeforeSlash",
+    &mut diagnostics,
+  );
+  handle_renamed_config_property(
+    &mut config,
     "jsx.spaceBeforeSelfClosingTagSlash",
+    "jsxSelfClosingElement.spaceBeforeSlash",
     &mut diagnostics,
   );
 
@@ -55,6 +61,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
   let quote_style = get_value(&mut config, "quoteStyle", QuoteStyle::AlwaysDouble, &mut diagnostics);
   let quote_props = get_value(&mut config, "quoteProps", QuoteProps::Preserve, &mut diagnostics);
   let space_around = get_value(&mut config, "spaceAround", false, &mut diagnostics);
+  let jsx_bracket_position = get_value(&mut config, "jsx.bracketPosition", SameOrNextLinePosition::NextLine, &mut diagnostics);
 
   let resolved_config = Configuration {
     line_width: get_value(
@@ -91,7 +98,8 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     jsx_quote_style: get_value(&mut config, "jsx.quoteStyle", quote_style.to_jsx_quote_style(), &mut diagnostics),
     jsx_multi_line_parens: get_value(&mut config, "jsx.multiLineParens", JsxMultiLineParens::Prefer, &mut diagnostics),
     jsx_force_new_lines_surrounding_content: get_value(&mut config, "jsx.forceNewLinesSurroundingContent", false, &mut diagnostics),
-    jsx_bracket_position: get_value(&mut config, "jsx.bracketPosition", SameOrNextLinePosition::NextLine, &mut diagnostics),
+    jsx_opening_element_bracket_position: get_value(&mut config, "jsxOpeningElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
+    jsx_self_closing_element_bracket_position: get_value(&mut config, "jsxSelfClosingElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
     member_expression_line_per_expression: get_value(&mut config, "memberExpression.linePerExpression", false, &mut diagnostics),
     type_literal_separator_kind_single_line: get_value(
       &mut config,
@@ -268,7 +276,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     if_statement_space_after_if_keyword: get_value(&mut config, "ifStatement.spaceAfterIfKeyword", true, &mut diagnostics),
     import_declaration_space_surrounding_named_imports: get_value(&mut config, "importDeclaration.spaceSurroundingNamedImports", true, &mut diagnostics),
     jsx_expression_container_space_surrounding_expression: get_value(&mut config, "jsxExpressionContainer.spaceSurroundingExpression", false, &mut diagnostics),
-    jsx_space_before_self_closing_tag_slash: get_value(&mut config, "jsx.spaceBeforeSelfClosingTagSlash", true, &mut diagnostics),
+    jsx_self_closing_element_space_before_slash: get_value(&mut config, "jsxSelfClosingElement.spaceBeforeSlash", true, &mut diagnostics),
     method_space_before_parentheses: get_value(&mut config, "method.spaceBeforeParentheses", false, &mut diagnostics),
     object_expression_space_surrounding_properties: get_value(
       &mut config,

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -289,8 +289,10 @@ pub struct Configuration {
   pub jsx_multi_line_parens: JsxMultiLineParens,
   #[serde(rename = "jsx.forceNewLinesSurroundingContent")]
   pub jsx_force_new_lines_surrounding_content: bool,
-  #[serde(rename = "jsx.bracketPosition")]
-  pub jsx_bracket_position: SameOrNextLinePosition,
+  #[serde(rename = "jsxOpeningElement.bracketPosition")]
+  pub jsx_opening_element_bracket_position: SameOrNextLinePosition,
+  #[serde(rename = "jsxSelfClosingElement.bracketPosition")]
+  pub jsx_self_closing_element_bracket_position: SameOrNextLinePosition,
   #[serde(rename = "memberExpression.linePerExpression")]
   pub member_expression_line_per_expression: bool,
   #[serde(rename = "typeLiteral.separatorKind.singleLine")]
@@ -559,8 +561,8 @@ pub struct Configuration {
   pub import_declaration_space_surrounding_named_imports: bool,
   #[serde(rename = "jsxExpressionContainer.spaceSurroundingExpression")]
   pub jsx_expression_container_space_surrounding_expression: bool,
-  #[serde(rename = "jsx.spaceBeforeSelfClosingTagSlash")]
-  pub jsx_space_before_self_closing_tag_slash: bool,
+  #[serde(rename = "jsxSelfClosingElement.spaceBeforeSlash")]
+  pub jsx_self_closing_element_space_before_slash: bool,
   #[serde(rename = "method.spaceBeforeParentheses")]
   pub method_space_before_parentheses: bool,
   #[serde(rename = "objectExpression.spaceSurroundingProperties")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3598,7 +3598,7 @@ fn gen_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Contex
 }
 
 fn gen_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItems {
-  let space_before_self_closing_tag_slash = context.config.jsx_space_before_self_closing_tag_slash;
+  let space_before_self_closing_tag_slash = context.config.jsx_self_closing_element_space_before_slash;
   let force_use_new_lines = get_force_is_multi_line(node, context);
   let prefer_newline_before_close_bracket = get_should_prefer_newline_before_close_bracket(node, context);
   let start_lsil = LineStartIndentLevel::new("openingElementStart");
@@ -3672,7 +3672,11 @@ fn gen_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Contex
   }
 
   fn get_should_prefer_newline_before_close_bracket(node: &JSXOpeningElement, context: &mut Context) -> bool {
-    match context.config.jsx_bracket_position {
+    let bracket_pos_config = match node.self_closing() {
+      true => context.config.jsx_self_closing_element_bracket_position,
+      false => context.config.jsx_opening_element_bracket_position,
+    };
+    match bracket_pos_config {
       SameOrNextLinePosition::Maintain => {
         if let Some(last_attr) = node.attrs.last() {
           last_attr.end_line_fast(context.program) < node.end_line_fast(context.program)

--- a/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_Maintain.txt
+++ b/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_Maintain.txt
@@ -1,5 +1,5 @@
 -- file.tsx --
-~~  lineWidth: 50, jsx.bracketPosition: maintain ~~
+~~  lineWidth: 50, jsxOpeningElement.bracketPosition: maintain ~~
 == should maintain the bracket position when there's attributes ==
 const t = (
     <Test
@@ -26,11 +26,6 @@ const w = (
         other={10}
     />
 );
-const x = (
-    <Test
-        prop={5}
-        other={10} />
-);
 
 [expect]
 const t = (
@@ -56,11 +51,6 @@ const w = (
         prop={5}
         other={10}
     />
-);
-const x = (
-    <Test
-        prop={5}
-        other={10} />
 );
 
 == should maintain for single line ==

--- a/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_NextLine.txt
+++ b/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_NextLine.txt
@@ -1,0 +1,63 @@
+-- file.tsx --
+~~  lineWidth: 50, jsxOpeningElement.bracketPosition: nextLine ~~
+== should move the bracket position to the next line ==
+const t = (
+    <Test
+    prop={5}
+    other={10}>
+        Test
+    </Test>
+);
+const u = (
+    <Test
+        prop={5}
+        other={10}
+    >
+    </Test>
+);
+const v = (
+    <Test
+    >
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+
+[expect]
+const t = (
+    <Test
+        prop={5}
+        other={10}
+    >
+        Test
+    </Test>
+);
+const u = (
+    <Test
+        prop={5}
+        other={10}
+    >
+    </Test>
+);
+const v = (
+    <Test>
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+
+== should maintain for single line ==
+const t = <MyComponent someProp={value} />;
+const u = <MyComponent></MyComponent>;
+
+[expect]
+const t = <MyComponent someProp={value} />;
+const u = <MyComponent></MyComponent>;

--- a/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_SameLine.txt
+++ b/tests/specs/jsx/JsxElement/JsxOpeningElement_BracketPosition_SameLine.txt
@@ -1,6 +1,6 @@
 -- file.tsx --
-~~  lineWidth: 50, jsx.bracketPosition: nextLine ~~
-== should move the bracket position to the next line ==
+~~  lineWidth: 50, jsxOpeningElement.bracketPosition: sameLine ~~
+== should move the bracket position to the same line ==
 const t = (
     <Test
     prop={5}
@@ -31,16 +31,14 @@ const w = (
 const t = (
     <Test
         prop={5}
-        other={10}
-    >
+        other={10}>
         Test
     </Test>
 );
 const u = (
     <Test
         prop={5}
-        other={10}
-    >
+        other={10}>
     </Test>
 );
 const v = (

--- a/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_Maintain.txt
+++ b/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_Maintain.txt
@@ -1,0 +1,48 @@
+-- file.tsx --
+~~  lineWidth: 50, jsxSelfClosingElement.bracketPosition: maintain ~~
+== should maintain the bracket position when there's attributes ==
+const t = (
+    <Test
+    prop={5}
+    other={10}>
+        Test
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+const x = (
+    <Test
+        prop={5}
+        other={10} />
+);
+
+[expect]
+const t = (
+    <Test
+        prop={5}
+        other={10}
+    >
+        Test
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+const x = (
+    <Test
+        prop={5}
+        other={10} />
+);
+
+== should maintain for single line ==
+const t = <MyComponent someProp={value} />;
+
+[expect]
+const t = <MyComponent someProp={value} />;

--- a/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_NextLine.txt
+++ b/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_NextLine.txt
@@ -1,0 +1,38 @@
+-- file.tsx --
+~~  lineWidth: 50, jsxSelfClosingElement.bracketPosition: nextLine ~~
+== should move the bracket position to the next line ==
+const t = (
+    <Test
+    prop={5}
+    other={10}>
+        Test
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+
+[expect]
+const t = (
+    <Test
+        prop={5}
+        other={10}
+    >
+        Test
+    </Test>
+);
+const w = (
+    <Test
+        prop={5}
+        other={10}
+    />
+);
+
+== should maintain for single line ==
+const t = <MyComponent someProp={value} />;
+
+[expect]
+const t = <MyComponent someProp={value} />;

--- a/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_SameLine.txt
+++ b/tests/specs/jsx/JsxElement/JsxSelfClosingElement_BracketPosition_SameLine.txt
@@ -1,23 +1,11 @@
 -- file.tsx --
-~~  lineWidth: 50, jsx.bracketPosition: sameLine ~~
+~~  lineWidth: 50, jsxSelfClosingElement.bracketPosition: sameLine ~~
 == should move the bracket position to the same line ==
 const t = (
     <Test
     prop={5}
     other={10}>
         Test
-    </Test>
-);
-const u = (
-    <Test
-        prop={5}
-        other={10}
-    >
-    </Test>
-);
-const v = (
-    <Test
-    >
     </Test>
 );
 const w = (
@@ -31,18 +19,9 @@ const w = (
 const t = (
     <Test
         prop={5}
-        other={10}>
+        other={10}
+    >
         Test
-    </Test>
-);
-const u = (
-    <Test
-        prop={5}
-        other={10}>
-    </Test>
-);
-const v = (
-    <Test>
     </Test>
 );
 const w = (
@@ -53,8 +32,6 @@ const w = (
 
 == should maintain for single line ==
 const t = <MyComponent someProp={value} />;
-const u = <MyComponent></MyComponent>;
 
 [expect]
 const t = <MyComponent someProp={value} />;
-const u = <MyComponent></MyComponent>;

--- a/tests/specs/jsx/JsxElement/JsxSelfClosingElement_SpaceBeforeSlash_False.txt
+++ b/tests/specs/jsx/JsxElement/JsxSelfClosingElement_SpaceBeforeSlash_False.txt
@@ -1,5 +1,5 @@
 -- file.tsx --
-~~ jsx.spaceBeforeSelfClosingTagSlash: false, lineWidth: 40 ~~
+~~ jsxSelfClosingElement.spaceBeforeSlash: false, lineWidth: 40 ~~
 == should avoid space before self closing tag when there are no attributes ==
 const t = <Test />;
 


### PR DESCRIPTION
Adds:

* `jsxSelfClosingElement.bracketSpacing`
* `jsxOpeningElement.bracketSpacing`

As discussed in #445

Renames `jsx.spaceBeforeSelfClosingTagSlash` -> `jsxSelfClosingElement.spaceBeforeSlash` for consistency.