### PR TITLE
fix: correct formatting comment after tailing comma on single line with `"trailingCommas": "always"`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-development"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9742cd442ec98a5a9a7ec3fe8c9e0baecf48794cce2d702ffd5d442c910bd6e1"
+checksum = "156dcd0b16dd5424774ccc56863c2990a7fb337aa0c9ac293bbe3cf6f632e297"
 dependencies = [
  "anyhow",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 debug-here = "0.2"
-dprint-development = "0.9.1"
+dprint-development = "0.9.2"
 serde_json = { version = "1.0" }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7050,6 +7050,7 @@ where
           Signal::NewLine.into(),
         ));
       } else {
+        let last_comma_token = nodes.last().and_then(|n| context.token_finder.get_next_token_if_comma(n));
         items.extend(gen_separated_values(
           GenSeparatedValuesParams {
             nodes: nodes.into_iter().map(NodeOrSeparator::Node).collect(),
@@ -7066,6 +7067,10 @@ where
           },
           context,
         ));
+        // the comma may disappear, so generate any trailing comments on the same line
+        if let Some(last_comma_token) = last_comma_token {
+          items.extend(gen_trailing_comments_same_line(&last_comma_token.range(), context));
+        }
       }
 
       items

--- a/tests/specs/general/Parameters_All.txt
+++ b/tests/specs/general/Parameters_All.txt
@@ -70,3 +70,27 @@ export async function acceptWebSocket(req = {
     other: 7,
 }): Promise<WebSocket> {
 }
+
+== should keep comment and remove trailing comma on single line ==
+function test(test, /* test */) {
+}
+
+[expect]
+function test(test /* test */) {
+}
+
+== should handle comments on next line ==
+function test(
+    test, /* test */
+    /* test */
+    // test
+) {
+}
+
+[expect]
+function test(
+    test, /* test */
+    /* test */
+    // test
+) {
+}

--- a/tests/specs/issues/issue0440.txt
+++ b/tests/specs/issues/issue0440.txt
@@ -1,0 +1,14 @@
+~~ indentWidth: 2, quoteStyle: alwaysSingle, semiColons: always, trailingCommas: always ~~
+== should handle comment in place of parameter ==
+function hasDeepProp(target /* , param1, param2, ... */) {
+}
+
+function hasDeepProp(target, /* , param1, param2, ... */) {
+}
+
+[expect]
+function hasDeepProp(target, /* , param1, param2, ... */) {
+}
+
+function hasDeepProp(target, /* , param1, param2, ... */) {
+}


### PR DESCRIPTION
Closes #440