### PR TITLE
conditionals: add support for nested indentation

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -747,6 +747,11 @@ impl ConfigurationBuilder {
     self.insert("whileStatement.preferHanging", value.into())
   }
 
+  /* situational indentation */
+  pub fn conditional_expression_use_nested_indentation(&mut self, value: bool) -> &mut Self {
+    self.insert("conditionalExpression.useNestedIndentation", value.into())
+  }
+
   /* force single line */
 
   pub fn export_declaration_force_single_line(&mut self, value: bool) -> &mut Self {
@@ -1138,6 +1143,8 @@ mod tests {
       .union_and_intersection_type_prefer_hanging(true)
       .variable_statement_prefer_hanging(true)
       .while_statement_prefer_hanging(true)
+      /* situational indentation */
+      .conditional_expression_use_nested_indentation(false)
       /* member spacing */
       .enum_declaration_member_spacing(MemberSpacing::Maintain)
       /* next control flow position */
@@ -1246,7 +1253,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 175);
+    assert_eq!(inner_config.len(), 176);
     let diagnostics = resolve_config(inner_config, &resolve_global_config(ConfigKeyMap::new(), &Default::default()).config).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -169,6 +169,8 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     union_and_intersection_type_prefer_hanging: get_value(&mut config, "unionAndIntersectionType.preferHanging", prefer_hanging, &mut diagnostics),
     variable_statement_prefer_hanging: get_value(&mut config, "variableStatement.preferHanging", prefer_hanging, &mut diagnostics),
     while_statement_prefer_hanging: get_value(&mut config, "whileStatement.preferHanging", prefer_hanging, &mut diagnostics),
+    /* situational indentation */
+    conditional_expression_use_nested_indentation: get_value(&mut config, "conditionalExpression.useNestedIndentation", false, &mut diagnostics),
     /* member spacing */
     enum_declaration_member_spacing: get_value(&mut config, "enumDeclaration.memberSpacing", MemberSpacing::Maintain, &mut diagnostics),
     /* next control flow position */

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -405,6 +405,9 @@ pub struct Configuration {
   pub variable_statement_prefer_hanging: bool,
   #[serde(rename = "whileStatement.preferHanging")]
   pub while_statement_prefer_hanging: bool,
+  /* situational indentation */
+  #[serde(rename = "conditionalExpression.useNestedIndentation")]
+  pub conditional_expression_use_nested_indentation: bool,
   /* member spacing */
   #[serde(rename = "enumDeclaration.memberSpacing")]
   pub enum_declaration_member_spacing: MemberSpacing,

--- a/tests/specs/expressions/ConditionalExpression/ConditionalExpression_UseNestedIndentation_True.txt
+++ b/tests/specs/expressions/ConditionalExpression/ConditionalExpression_UseNestedIndentation_True.txt
@@ -1,0 +1,34 @@
+~~ lineWidth: 80, conditionalExpression.useNestedIndentation: true ~~
+== should handle nested indentation on a basic ternary / conditional expression ==
+const value = is_prod
+? do1()
+:  is_laptop
+? do2()
+: do3();
+
+[expect]
+const value = is_prod
+    ? do1()
+    : is_laptop
+        ? do2()
+        : do3();
+
+== should handle nested indentation with extends and mapped types ==
+export type R<S> = S extends Record<string, T<any, any>> ? { [K in keyof S]: ReturnType<S[K][1]> } : S extends T<infer _T, any>
+? _T extends Array<infer I>
+? I
+: _T : S extends SZ<infer _T, any> ? _T : S extends DZ<infer _T>
+? _T : never;
+
+[expect]
+export type R<S> = S extends Record<string, T<any, any>>
+    ? { [K in keyof S]: ReturnType<S[K][1]> }
+    : S extends T<infer _T, any>
+        ? _T extends Array<infer I>
+            ? I
+            : _T
+        : S extends SZ<infer _T, any>
+            ? _T
+            : S extends DZ<infer _T>
+                ? _T
+                : never;


### PR DESCRIPTION
We've had this in our fork for over a year now, and I noticed https://github.com/dprint/dprint-plugin-typescript/issues/432 pop up. 

This PR adds support for nested indentation in conditional types and expressions, so that it formats as a tree. 