### PR TITLE
debugging: add launch.json configuration for CodeLLDB-based debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,25 @@
       "environment": [],
       "externalConsole": false,
       "preLaunchTask": "cargo test build"
+    },
+    {
+      "name": "Debug Tests (macOS)",
+      "type": "lldb",
+      "request": "launch",
+      "cargo": {
+        "args": [
+          "test",
+          "--no-run",
+          "--test=test",
+          "--package=dprint-plugin-typescript"
+        ],
+        "filter": {
+          "name": "test",
+          "kind": "test"
+        }
+      },
+      "args": [],
+      "cwd": "${workspaceFolder}"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,18 +6,6 @@
   "configurations": [
     {
       "name": "Debug Tests",
-      "type": "cppvsdbg",
-      "request": "launch",
-      "program": "${workspaceFolder}/target/debug/test-f8914282c3a53115.exe",
-      "args": [],
-      "stopAtEntry": false,
-      "cwd": "${workspaceFolder}",
-      "environment": [],
-      "externalConsole": false,
-      "preLaunchTask": "cargo test build"
-    },
-    {
-      "name": "Debug Tests (macOS)",
       "type": "lldb",
       "request": "launch",
       "cargo": {


### PR DESCRIPTION
This PR adds a launch.json config to allow debugging via the CodeLLDB extension, which is how I do it on my Macbook. 

It might work on Windows as well, could you try? If so, then we can probably just delete the other launch configuration.

![image](https://user-images.githubusercontent.com/13516619/208656001-52b7d78f-3be1-4294-afcb-9b0a4cecfad6.png)
