### PR TITLE
fix: unwrap outer parens if it's the RHS of a var declaration

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2728,6 +2728,14 @@ fn should_skip_paren_expr(node: &ParenExpr, context: &Context) -> bool {
     }
   }
 
+  if let Node::VarDeclarator(var_decl) = parent {
+    if let Some(init) = var_decl.init {
+      if init.range().contains(&node.range()) {
+        return true;
+      }
+    }
+  }
+
   // skip over an expr or spread if not a spread
   if let Some(expr_or_spread) = parent.to::<ExprOrSpread>() {
     // these should only appear in these nodes

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2722,6 +2722,12 @@ fn should_skip_paren_expr(node: &ParenExpr, context: &Context) -> bool {
     return true;
   }
 
+  // skip explicitly parsing this as a paren expr as that will be handled
+  // in the JSX element/fragment and it might collapse back to not having a paren expr
+  if matches!(node.expr.kind(), NodeKind::JSXElement | NodeKind::JSXFragment) {
+    return is_jsx_paren_expr_handled_node(node.expr.into(), context);
+  }
+
   if let Node::AssignExpr(assign_expr) = parent {
     if assign_expr.right.range().contains(&node.range()) {
       return true;
@@ -2755,9 +2761,7 @@ fn should_skip_paren_expr(node: &ParenExpr, context: &Context) -> bool {
     }
   }
 
-  // skip explicitly parsing this as a paren expr as that will be handled
-  // in the JSX element/fragment and it might collapse back to not having a paren expr
-  is_jsx_paren_expr_handled_node(node.expr.into(), context)
+  false
 }
 
 fn gen_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> PrintItems {

--- a/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
+++ b/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
@@ -26,7 +26,7 @@ const test = (
 [expect]
 (x.test as unknown) = 6;
 
-== should not keep paren expr on right hand side of assignment (only) ==
+== should not keep paren expr on right hand side of assignment ==
 const a = (1);
 const b = ((((1))));
 const c = (1 + 1) + 1;

--- a/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
+++ b/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
@@ -26,6 +26,18 @@ const test = (
 [expect]
 (x.test as unknown) = 6;
 
+== should not keep paren expr on right hand side of assignment (only) ==
+const a = (1);
+const b = ((((1))));
+const c = (1 + 1) + 1;
+const d = 1 + (1 + 1);
+
+[expect]
+const a = 1;
+const b = 1;
+const c = (1 + 1) + 1;
+const d = 1 + (1 + 1);
+
 == should ignore paren exprs within paren exprs ==
 (((test)));
 (

--- a/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
+++ b/tests/specs/expressions/ParenExpr/ParenExpr_All.txt
@@ -31,12 +31,16 @@ const a = (1);
 const b = ((((1))));
 const c = (1 + 1) + 1;
 const d = 1 + (1 + 1);
+// except here it should because of the type assertion
+const e = /** @type {number} */ (((1)));
 
 [expect]
 const a = 1;
 const b = 1;
 const c = (1 + 1) + 1;
 const d = 1 + (1 + 1);
+// except here it should because of the type assertion
+const e = /** @type {number} */ (1);
 
 == should ignore paren exprs within paren exprs ==
 (((test)));


### PR DESCRIPTION
Input:
```ts
const a = (((1)));
```

Expected:
```ts
const a = 1;
```

Actual:
```ts
const a = (1);
```

Seems like this was perhaps meant to be handled by the `AssignExpr` immediately above where I made my change, but I debugged it and it seems to be a `VarDeclarator` instead. 