### PR TITLE
comments: trim excessive whitespace at the start of multi-line block comments

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -6354,7 +6354,7 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
 
   return Some(match comment.kind {
     CommentKind::Block => {
-      if is_js_doc_or_multiline_block(&comment.text) {
+      if has_leading_astrisk_each_line(&comment.text) {
         gen_js_doc_or_multiline_block(comment, context)
       } else {
         // Single-line comment block
@@ -6364,20 +6364,19 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
     CommentKind::Line => ir_helpers::gen_js_like_comment_line(&comment.text, context.config.comment_line_force_space_after_slashes),
   });
 
-  fn is_js_doc_or_multiline_block(text: &str) -> bool {
-    // be strict about what a js doc is for now
-    if text.contains('\n') {
-      for line in text.trim().split('\n') {
-        let first_non_whitespace = line.trim_start().chars().next();
-        if !matches!(first_non_whitespace, Some('*')) {
-          return false;
-        }
-      }
-
-      true
-    } else {
-      false
+  fn has_leading_astrisk_each_line(text: &str) -> bool {
+    if !text.contains('\n') {
+      return false;
     }
+
+    for line in text.trim().split('\n') {
+      let first_non_whitespace = line.trim_start().chars().next();
+      if !matches!(first_non_whitespace, Some('*')) {
+        return false;
+      }
+    }
+
+    true
   }
 }
 

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -6367,7 +6367,7 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
   fn is_js_doc_or_multiline_block(text: &str) -> bool {
     // be strict about what a js doc is for now
     if text.contains('\n') {
-      for line in text.trim().split('\n').skip(1) {
+      for line in text.trim().split('\n') {
         let first_non_whitespace = line.trim_start().chars().next();
         if !matches!(first_non_whitespace, Some('*')) {
           return false;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -6354,18 +6354,19 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
 
   return Some(match comment.kind {
     CommentKind::Block => {
-      if is_js_doc(&comment.text) {
-        gen_js_doc(comment, context)
+      if is_js_doc_or_multiline_block(&comment.text) {
+        gen_js_doc_or_multiline_block(comment, context)
       } else {
+        // Single-line comment block
         ir_helpers::gen_js_like_comment_block(&comment.text)
       }
     }
     CommentKind::Line => ir_helpers::gen_js_like_comment_line(&comment.text, context.config.comment_line_force_space_after_slashes),
   });
 
-  fn is_js_doc(text: &str) -> bool {
+  fn is_js_doc_or_multiline_block(text: &str) -> bool {
     // be strict about what a js doc is for now
-    if text.starts_with('*') && text.contains('\n') {
+    if text.contains('\n') {
       for line in text.trim().split('\n').skip(1) {
         let first_non_whitespace = line.trim_start().chars().next();
         if !matches!(first_non_whitespace, Some('*')) {
@@ -6380,8 +6381,9 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
   }
 }
 
-fn gen_js_doc(comment: &Comment, _context: &mut Context) -> PrintItems {
-  return lines_to_print_items(build_lines(comment));
+fn gen_js_doc_or_multiline_block(comment: &Comment, _context: &mut Context) -> PrintItems {
+  let is_js_doc = comment.text.starts_with('*');
+  return lines_to_print_items(is_js_doc, build_lines(comment));
 
   fn build_lines(comment: &Comment) -> Vec<&str> {
     let mut lines: Vec<&str> = Vec::new();
@@ -6408,7 +6410,7 @@ fn gen_js_doc(comment: &Comment, _context: &mut Context) -> PrintItems {
     0
   }
 
-  fn lines_to_print_items(lines: Vec<&str>) -> PrintItems {
+  fn lines_to_print_items(is_js_doc: bool, lines: Vec<&str>) -> PrintItems {
     let mut items = PrintItems::new();
 
     items.push_str("/*");
@@ -6418,8 +6420,12 @@ fn gen_js_doc(comment: &Comment, _context: &mut Context) -> PrintItems {
         items.push_signal(Signal::NewLine);
       }
       let mut text = String::new();
-      // leading asterisk
-      text.push_str(if i == 0 { "*" } else { " *" });
+      // leading asterisk on the first line for jsdoc only
+      if is_js_doc && i == 0 {
+        text.push_str("*");
+      } else if i > 0 {
+        text.push_str(" *");
+      }
 
       // line start space
       let is_space_or_asterisk = matches!(line.chars().next(), Some('*' | ' '));

--- a/tests/specs/comments/CommentBlocks_All.txt
+++ b/tests/specs/comments/CommentBlocks_All.txt
@@ -73,7 +73,7 @@ class Test {
 class Test {
 }
 
-== should handle changing indentation of block comments (only) ==
+== should handle changing indentation of block comments ==
       /*
              * A
         * B

--- a/tests/specs/comments/CommentBlocks_All.txt
+++ b/tests/specs/comments/CommentBlocks_All.txt
@@ -73,6 +73,20 @@ class Test {
 class Test {
 }
 
+== should handle changing indentation of block comments (only) ==
+      /*
+             * A
+        * B
+             */
+const t;
+
+[expect]
+/*
+ * A
+ * B
+ */
+const t;
+
 == should format comments in arguments ==
 call(/* test */5);
 


### PR DESCRIPTION
Block comments like this:
```
/*
    * hello
        * world!
 */
```
should get the same leading whitespace / indentation treatment as JSDoc. This PR aligns that and tweaks the JSDoc code to allow it, instead of using the super-basic `js_like_comment_block` in dprint core. I did start out fixing `js_like_comment_block` first, but that change got far too involved (especially for `core`, which is language agnostic), and this change was much shorter and also gives us future parity with any similar JSDoc improvements.

This aligns with Prettier: https://prettier.io/playground/#N4Igxg9gdgLgprEAuEB6AVAHSgAj+nAWwE8cBDQsgLwEsoBzHSQwhGbPHdVbSKAZxg4AZhAg4AvDgCMAbmzYMWXPiKkK1Oo2atYHfDyh9BIsZJmyQAGhAQADjBrR+yUGQBO7iAHcACh4QXFDIAG28yYhcbACN3MjAAazgYAGUKOAAZOjhkYVD+OBi4xOSUu3itZBh3AFdCkDhCaLgAExbWjLIGGrJ6OAAxCHdKGEcGZBAyGpgIaxAACxhCEIB1eZp4fnKwOBTAjZoANw3iCbB+KJA6AvcYXzj6Slz8+oArfgAPFK0QuABFGoQeDPEIFGzldw3CbRMjNEJzOzuOgwFY0FowebIAAcAAZwV4Cis4nYJoi4DdDjkbABHQHwe72IKTfgAWigcFarTm7jgtJoPPuvSeSDyoPqBUINCqtXFPzgAEFRkjotM4L44O4suyQWCQPw5QCgTkRS8bDBYaj0ZikAAmM1xGghLQAYQgLDIE3JAFY5jUCgAVWFBUW6w51ACSUHasBSYCRDnlUZSMGIvx1cAAvhmgA

