### PR TITLE
fix: braces in blocks with conditional braces should not be removed when containing a single empty statement

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -8336,7 +8336,7 @@ fn gen_conditional_brace_body<'a>(opts: GenConditionalBraceBodyOptions<'a>, cont
 
   fn get_force_braces(body_node: Node) -> bool {
     if let Node::BlockStmt(body_node) = body_node {
-      body_node.stmts.is_empty()
+      body_node.stmts.is_empty() || body_node.stmts.iter().all(|s| s.kind() == NodeKind::EmptyStmt)
     } else {
       false
     }

--- a/tests/specs/issues/issue0468.txt
+++ b/tests/specs/issues/issue0468.txt
@@ -1,0 +1,19 @@
+== should not remove the braces in an if/while statement when the body contains empty statements ==
+if (true) {;}
+while (true) {;}
+
+// these going multi-line is ok... nobody should be writing this
+// and fixing it just adds more complexity
+if (true) {;;}
+while (true) {;;}
+
+[expect]
+if (true) {}
+while (true) {}
+
+// these going multi-line is ok... nobody should be writing this
+// and fixing it just adds more complexity
+if (true) {
+}
+while (true) {
+}


### PR DESCRIPTION
Closes #468