### PR TITLE
feat: preferHanging - add onlySingleItem option for some config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,61 +14,6 @@ See the GitHub [releases](https://github.com/dprint/dprint-plugin-typescript/rel
 
 The tests are in the `./tests/specs` folder. To run the tests, run `cargo test`.
 
-### Concepts
-
-#### `gen_separated_values`
-
-A general function that is both in dprint core and the typescript plugin. It's used for everything from arrays, arguments, type parameters, objects, etc. The general vibe is to use `multiline_options` to control its behaviour from more specific callees like `gen_parameters_or_arguments`.
-
-#### Inline vs not-inline
-
-#### Singleline vs hanging vs multiline
-
-### Tips
-
-1. To use `println` together with `cargo test`, you need to invoke tests in this strange way [ (for reasons) ](https://github.com/rust-lang/cargo/issues/296):
-
-```sh
-cargo test -- --nocapture
-```
-
-2. Make sure your test files end in a final blank line, otherwise you'll get an error during testing with a diff that appears identical.
-
-### Debugging
-
-Live-step debugging is especially useful for a couple use cases:
-1. Seeing what AST nodes are generated from source code
-2. Seeing what IR (intermediate representation) is generated from AST nodes
-2. Seeing how the printer converts the IR into a formatted file
-
-#### Seeing what AST nodes or IR is generated from source code
-
-Here's how to get debugging the first two use cases (on VSCode):
-
-1. Add a test to a new file `tests/specs/debug.txt` and give it the `(only)` suffix. Note that an empty line is required at the end of the file. For example:
-
-```
-// tests/specs/debug.txt
-~~ lineWidth: 40, arguments.preferHanging: true ~~
-== investigate the node types generated from source code (only) ==
-let a = b + c;
-
-[expect]
-let a = b + c;
-
-```
-
-2. Install the [rust-analyzer plugin](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
-3. Add a breakpoint somewhere, e.g. in `src/generation/generate.rs` inside the `gen_node_inner` function to see what sort of AST nodes correspond to source code.
-4. Head to `tests/test.rs` and click the `Debug` button hovering above the implementation for the `test_specs` function.
-
-And now you can step to your heart's delight!
-
-#### Seeing what output code is printed from IR (and which AST nodes it came from)
-
-tldr:
-- use `items.push_info(LineNumber::new("START"))` 
-
 ### Building Wasm file
 
 You may wish to try out the plugin by building from source:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,61 @@ See the GitHub [releases](https://github.com/dprint/dprint-plugin-typescript/rel
 
 The tests are in the `./tests/specs` folder. To run the tests, run `cargo test`.
 
+### Concepts
+
+#### `gen_separated_values`
+
+A general function that is both in dprint core and the typescript plugin. It's used for everything from arrays, arguments, type parameters, objects, etc. The general vibe is to use `multiline_options` to control its behaviour from more specific callees like `gen_parameters_or_arguments`.
+
+#### Inline vs not-inline
+
+#### Singleline vs hanging vs multiline
+
+### Tips
+
+1. To use `println` together with `cargo test`, you need to invoke tests in this strange way [ (for reasons) ](https://github.com/rust-lang/cargo/issues/296):
+
+```sh
+cargo test -- --nocapture
+```
+
+2. Make sure your test files end in a final blank line, otherwise you'll get an error during testing with a diff that appears identical.
+
+### Debugging
+
+Live-step debugging is especially useful for a couple use cases:
+1. Seeing what AST nodes are generated from source code
+2. Seeing what IR (intermediate representation) is generated from AST nodes
+2. Seeing how the printer converts the IR into a formatted file
+
+#### Seeing what AST nodes or IR is generated from source code
+
+Here's how to get debugging the first two use cases (on VSCode):
+
+1. Add a test to a new file `tests/specs/debug.txt` and give it the `(only)` suffix. Note that an empty line is required at the end of the file. For example:
+
+```
+// tests/specs/debug.txt
+~~ lineWidth: 40, arguments.preferHanging: true ~~
+== investigate the node types generated from source code (only) ==
+let a = b + c;
+
+[expect]
+let a = b + c;
+
+```
+
+2. Install the [rust-analyzer plugin](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).
+3. Add a breakpoint somewhere, e.g. in `src/generation/generate.rs` inside the `gen_node_inner` function to see what sort of AST nodes correspond to source code.
+4. Head to `tests/test.rs` and click the `Debug` button hovering above the implementation for the `test_specs` function.
+
+And now you can step to your heart's delight!
+
+#### Seeing what output code is printed from IR (and which AST nodes it came from)
+
+tldr:
+- use `items.push_info(LineNumber::new("START"))` 
+
 ### Building Wasm file
 
 You may wish to try out the plugin by building from source:

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -240,6 +240,21 @@
         "description": ""
       }]
     },
+    "preferHangingGranular": {
+      "description": "Set to prefer hanging indentation when exceeding the line width instead of making code split up on multiple lines.",
+      "type": "string",
+      "default": "never",
+      "oneOf": [{
+        "const": "always",
+        "description": "Always prefers hanging regardless of the number of elements."
+      }, {
+        "const": "onlySingleItem",
+        "description": "Only prefers hanging if there is a single item."
+      }, {
+        "const": "never",
+        "description": "Never prefers hanging."
+      }]
+    },
     "preferSingleLine": {
       "description": "If code should revert back from being on multiple lines to being on a single line when able.",
       "type": "boolean",
@@ -1125,10 +1140,10 @@
       "$ref": "#/definitions/operatorPosition"
     },
     "arguments.preferHanging": {
-      "$ref": "#/definitions/preferHanging"
+      "$ref": "#/definitions/preferHangingGranular"
     },
     "arrayExpression.preferHanging": {
-      "$ref": "#/definitions/preferHanging"
+      "$ref": "#/definitions/preferHangingGranular"
     },
     "arrayPattern.preferHanging": {
       "$ref": "#/definitions/preferHanging"
@@ -1170,7 +1185,7 @@
       "$ref": "#/definitions/preferHanging"
     },
     "parameters.preferHanging": {
-      "$ref": "#/definitions/preferHanging"
+      "$ref": "#/definitions/preferHangingGranular"
     },
     "sequenceExpression.preferHanging": {
       "$ref": "#/definitions/preferHanging"
@@ -1179,13 +1194,13 @@
       "$ref": "#/definitions/preferHanging"
     },
     "tupleType.preferHanging": {
-      "$ref": "#/definitions/preferHanging"
+      "$ref": "#/definitions/preferHangingGranular"
     },
     "typeLiteral.preferHanging": {
       "$ref": "#/definitions/preferHanging"
     },
     "typeParameters.preferHanging": {
-      "$ref": "#/definitions/preferHanging"
+      "$ref": "#/definitions/preferHangingGranular"
     },
     "unionAndIntersectionType.preferHanging": {
       "$ref": "#/definitions/preferHanging"

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -651,12 +651,12 @@ impl ConfigurationBuilder {
 
   /* prefer hanging */
 
-  pub fn arguments_prefer_hanging(&mut self, value: bool) -> &mut Self {
-    self.insert("arguments.preferHanging", value.into())
+  pub fn arguments_prefer_hanging(&mut self, value: PreferHanging) -> &mut Self {
+    self.insert("arguments.preferHanging", value.to_string().into())
   }
 
-  pub fn array_expression_prefer_hanging(&mut self, value: bool) -> &mut Self {
-    self.insert("arrayExpression.preferHanging", value.into())
+  pub fn array_expression_prefer_hanging(&mut self, value: PreferHanging) -> &mut Self {
+    self.insert("arrayExpression.preferHanging", value.to_string().into())
   }
 
   pub fn array_pattern_prefer_hanging(&mut self, value: bool) -> &mut Self {
@@ -711,8 +711,8 @@ impl ConfigurationBuilder {
     self.insert("objectPattern.preferHanging", value.into())
   }
 
-  pub fn parameters_prefer_hanging(&mut self, value: bool) -> &mut Self {
-    self.insert("parameters.preferHanging", value.into())
+  pub fn parameters_prefer_hanging(&mut self, value: PreferHanging) -> &mut Self {
+    self.insert("parameters.preferHanging", value.to_string().into())
   }
 
   pub fn sequence_expression_prefer_hanging(&mut self, value: bool) -> &mut Self {
@@ -723,16 +723,16 @@ impl ConfigurationBuilder {
     self.insert("switchStatement.preferHanging", value.into())
   }
 
-  pub fn tuple_type_prefer_hanging(&mut self, value: bool) -> &mut Self {
-    self.insert("tupleType.preferHanging", value.into())
+  pub fn tuple_type_prefer_hanging(&mut self, value: PreferHanging) -> &mut Self {
+    self.insert("tupleType.preferHanging", value.to_string().into())
   }
 
   pub fn type_literal_prefer_hanging(&mut self, value: bool) -> &mut Self {
     self.insert("typeLiteral.preferHanging", value.into())
   }
 
-  pub fn type_parameters_prefer_hanging(&mut self, value: bool) -> &mut Self {
-    self.insert("typeParameters.preferHanging", value.into())
+  pub fn type_parameters_prefer_hanging(&mut self, value: PreferHanging) -> &mut Self {
+    self.insert("typeParameters.preferHanging", value.to_string().into())
   }
 
   pub fn union_and_intersection_type_prefer_hanging(&mut self, value: bool) -> &mut Self {
@@ -1114,8 +1114,8 @@ mod tests {
       .try_statement_brace_position(BracePosition::NextLine)
       .while_statement_brace_position(BracePosition::NextLine)
       /* prefer hanging */
-      .arguments_prefer_hanging(true)
-      .array_expression_prefer_hanging(true)
+      .arguments_prefer_hanging(PreferHanging::OnlySingleItem)
+      .array_expression_prefer_hanging(PreferHanging::OnlySingleItem)
       .array_pattern_prefer_hanging(true)
       .do_while_statement_prefer_hanging(true)
       .export_declaration_prefer_hanging(true)
@@ -1129,12 +1129,12 @@ mod tests {
       .jsx_attributes_prefer_hanging(true)
       .object_expression_prefer_hanging(true)
       .object_pattern_prefer_hanging(true)
-      .parameters_prefer_hanging(true)
+      .parameters_prefer_hanging(PreferHanging::OnlySingleItem)
       .sequence_expression_prefer_hanging(true)
       .switch_statement_prefer_hanging(true)
-      .tuple_type_prefer_hanging(true)
+      .tuple_type_prefer_hanging(PreferHanging::OnlySingleItem)
       .type_literal_prefer_hanging(true)
-      .type_parameters_prefer_hanging(true)
+      .type_parameters_prefer_hanging(PreferHanging::OnlySingleItem)
       .union_and_intersection_type_prefer_hanging(true)
       .variable_statement_prefer_hanging(true)
       .while_statement_prefer_hanging(true)

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -54,6 +54,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
   let trailing_commas = get_value(&mut config, "trailingCommas", TrailingCommas::OnlyMultiLine, &mut diagnostics);
   let use_braces = get_value(&mut config, "useBraces", UseBraces::WhenNotSingleLine, &mut diagnostics);
   let prefer_hanging = get_value(&mut config, "preferHanging", false, &mut diagnostics);
+  let prefer_hanging_granular = if prefer_hanging { PreferHanging::Always } else { PreferHanging::Never };
   let prefer_single_line_nullable = get_nullable_value(&mut config, "preferSingleLine", &mut diagnostics);
   let prefer_single_line = prefer_single_line_nullable.unwrap_or(false);
   let space_surrounding_properties = get_value(&mut config, "spaceSurroundingProperties", true, &mut diagnostics);
@@ -145,8 +146,8 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     try_statement_brace_position: get_value(&mut config, "tryStatement.bracePosition", brace_position, &mut diagnostics),
     while_statement_brace_position: get_value(&mut config, "whileStatement.bracePosition", brace_position, &mut diagnostics),
     /* prefer hanging */
-    arguments_prefer_hanging: get_value(&mut config, "arguments.preferHanging", prefer_hanging, &mut diagnostics),
-    array_expression_prefer_hanging: get_value(&mut config, "arrayExpression.preferHanging", prefer_hanging, &mut diagnostics),
+    arguments_prefer_hanging: get_value(&mut config, "arguments.preferHanging", prefer_hanging_granular, &mut diagnostics),
+    array_expression_prefer_hanging: get_value(&mut config, "arrayExpression.preferHanging", prefer_hanging_granular, &mut diagnostics),
     array_pattern_prefer_hanging: get_value(&mut config, "arrayPattern.preferHanging", prefer_hanging, &mut diagnostics),
     do_while_statement_prefer_hanging: get_value(&mut config, "doWhileStatement.preferHanging", prefer_hanging, &mut diagnostics),
     export_declaration_prefer_hanging: get_value(&mut config, "exportDeclaration.preferHanging", prefer_hanging, &mut diagnostics),
@@ -160,12 +161,12 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     jsx_attributes_prefer_hanging: get_value(&mut config, "jsxAttributes.preferHanging", prefer_hanging, &mut diagnostics),
     object_expression_prefer_hanging: get_value(&mut config, "objectExpression.preferHanging", prefer_hanging, &mut diagnostics),
     object_pattern_prefer_hanging: get_value(&mut config, "objectPattern.preferHanging", prefer_hanging, &mut diagnostics),
-    parameters_prefer_hanging: get_value(&mut config, "parameters.preferHanging", prefer_hanging, &mut diagnostics),
+    parameters_prefer_hanging: get_value(&mut config, "parameters.preferHanging", prefer_hanging_granular, &mut diagnostics),
     sequence_expression_prefer_hanging: get_value(&mut config, "sequenceExpression.preferHanging", prefer_hanging, &mut diagnostics),
     switch_statement_prefer_hanging: get_value(&mut config, "switchStatement.preferHanging", prefer_hanging, &mut diagnostics),
-    tuple_type_prefer_hanging: get_value(&mut config, "tupleType.preferHanging", prefer_hanging, &mut diagnostics),
+    tuple_type_prefer_hanging: get_value(&mut config, "tupleType.preferHanging", prefer_hanging_granular, &mut diagnostics),
     type_literal_prefer_hanging: get_value(&mut config, "typeLiteral.preferHanging", prefer_hanging, &mut diagnostics),
-    type_parameters_prefer_hanging: get_value(&mut config, "typeParameters.preferHanging", prefer_hanging, &mut diagnostics),
+    type_parameters_prefer_hanging: get_value(&mut config, "typeParameters.preferHanging", prefer_hanging_granular, &mut diagnostics),
     union_and_intersection_type_prefer_hanging: get_value(&mut config, "unionAndIntersectionType.preferHanging", prefer_hanging, &mut diagnostics),
     variable_statement_prefer_hanging: get_value(&mut config, "variableStatement.preferHanging", prefer_hanging, &mut diagnostics),
     while_statement_prefer_hanging: get_value(&mut config, "whileStatement.preferHanging", prefer_hanging, &mut diagnostics),

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -114,6 +114,12 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
       type_literal_separator_kind,
       &mut diagnostics,
     ),
+    multi_line_force_multiple_multi_line_siblings_to_use_multi_lines: get_value(
+      &mut config,
+       "multiLine.forceMultipleMultiLineSiblingsToUseMultiLines",
+      false,
+      &mut diagnostics,
+    ),
     /* sorting */
     module_sort_import_declarations: get_value(&mut config, "module.sortImportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),
     module_sort_export_declarations: get_value(&mut config, "module.sortExportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -114,12 +114,6 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
       type_literal_separator_kind,
       &mut diagnostics,
     ),
-    multi_line_force_multiple_multi_line_siblings_to_use_multi_lines: get_value(
-      &mut config,
-       "multiLine.forceMultipleMultiLineSiblingsToUseMultiLines",
-      false,
-      &mut diagnostics,
-    ),
     /* sorting */
     module_sort_import_declarations: get_value(&mut config, "module.sortImportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),
     module_sort_export_declarations: get_value(&mut config, "module.sortExportDeclarations", SortOrder::CaseInsensitive, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -3,6 +3,25 @@ use dprint_core::generate_str_to_from;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PreferHanging {
+  /// Always prefer multi-line indentation
+  Never,
+  /// Prefer hanging indentation for sequences with only a single item, but if there are multiple
+  /// items then use multi-line indentation
+  OnlySingleItem,
+  /// Always prefer hanging indentation
+  Always,
+}
+
+generate_str_to_from![PreferHanging,
+  // Existing options (from upstream)
+  [Never, "false"], [Always, "true"],
+  // Modified options (from canva fork)
+  [Never, "never"], [OnlySingleItem, "onlySingleItem"], [Always, "always"]
+];
+
 /// Semi colon possibilities.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -358,9 +377,9 @@ pub struct Configuration {
   pub while_statement_brace_position: BracePosition,
   /* prefer hanging */
   #[serde(rename = "arguments.preferHanging")]
-  pub arguments_prefer_hanging: bool,
+  pub arguments_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayExpression.preferHanging")]
-  pub array_expression_prefer_hanging: bool,
+  pub array_expression_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayPattern.preferHanging")]
   pub array_pattern_prefer_hanging: bool,
   #[serde(rename = "doWhileStatement.preferHanging")]
@@ -388,17 +407,17 @@ pub struct Configuration {
   #[serde(rename = "objectPattern.preferHanging")]
   pub object_pattern_prefer_hanging: bool,
   #[serde(rename = "parameters.preferHanging")]
-  pub parameters_prefer_hanging: bool,
+  pub parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "sequenceExpression.preferHanging")]
   pub sequence_expression_prefer_hanging: bool,
   #[serde(rename = "switchStatement.preferHanging")]
   pub switch_statement_prefer_hanging: bool,
   #[serde(rename = "tupleType.preferHanging")]
-  pub tuple_type_prefer_hanging: bool,
+  pub tuple_type_prefer_hanging: PreferHanging,
   #[serde(rename = "typeLiteral.preferHanging")]
   pub type_literal_prefer_hanging: bool,
   #[serde(rename = "typeParameters.preferHanging")]
-  pub type_parameters_prefer_hanging: bool,
+  pub type_parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "unionAndIntersectionType.preferHanging")]
   pub union_and_intersection_type_prefer_hanging: bool,
   #[serde(rename = "variableStatement.preferHanging")]

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -15,12 +15,7 @@ pub enum PreferHanging {
   Always,
 }
 
-generate_str_to_from![PreferHanging,
-  // Existing options (from upstream)
-  [Never, "false"], [Always, "true"],
-  // Modified options (from canva fork)
-  [Never, "never"], [OnlySingleItem, "onlySingleItem"], [Always, "always"]
-];
+generate_str_to_from![PreferHanging, [Never, "never"], [OnlySingleItem, "onlySingleItem"], [Always, "always"]];
 
 /// Semi colon possibilities.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -318,8 +318,6 @@ pub struct Configuration {
   pub type_literal_separator_kind_single_line: SemiColonOrComma,
   #[serde(rename = "typeLiteral.separatorKind.multiLine")]
   pub type_literal_separator_kind_multi_line: SemiColonOrComma,
-  #[serde(rename = "multiLine.forceMultipleMultiLineSiblingsToUseMultiLines")]
-  pub multi_line_force_multiple_multi_line_siblings_to_use_multi_lines: bool,
   /* sorting */
   #[serde(rename = "module.sortImportDeclarations")]
   pub module_sort_import_declarations: SortOrder,
@@ -377,19 +375,12 @@ pub struct Configuration {
   pub try_statement_brace_position: BracePosition,
   #[serde(rename = "whileStatement.bracePosition")]
   pub while_statement_brace_position: BracePosition,
-  /* prefer hanging (with onlySingleItem option) */
+  /* prefer hanging */
   #[serde(rename = "arguments.preferHanging")]
   pub arguments_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayExpression.preferHanging")]
   pub array_expression_prefer_hanging: PreferHanging,
-  #[serde(rename = "parameters.preferHanging")]
-  pub parameters_prefer_hanging: PreferHanging,
-  #[serde(rename = "tupleType.preferHanging")]
-  pub tuple_type_prefer_hanging: PreferHanging,
-  #[serde(rename = "typeParameters.preferHanging")]
-  pub type_parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayPattern.preferHanging")]
-  /* prefer hanging */
   pub array_pattern_prefer_hanging: bool,
   #[serde(rename = "doWhileStatement.preferHanging")]
   pub do_while_statement_prefer_hanging: bool,
@@ -415,12 +406,18 @@ pub struct Configuration {
   pub object_expression_prefer_hanging: bool,
   #[serde(rename = "objectPattern.preferHanging")]
   pub object_pattern_prefer_hanging: bool,
+  #[serde(rename = "parameters.preferHanging")]
+  pub parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "sequenceExpression.preferHanging")]
   pub sequence_expression_prefer_hanging: bool,
   #[serde(rename = "switchStatement.preferHanging")]
   pub switch_statement_prefer_hanging: bool,
+  #[serde(rename = "tupleType.preferHanging")]
+  pub tuple_type_prefer_hanging: PreferHanging,
   #[serde(rename = "typeLiteral.preferHanging")]
   pub type_literal_prefer_hanging: bool,
+  #[serde(rename = "typeParameters.preferHanging")]
+  pub type_parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "unionAndIntersectionType.preferHanging")]
   pub union_and_intersection_type_prefer_hanging: bool,
   #[serde(rename = "variableStatement.preferHanging")]

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -318,6 +318,8 @@ pub struct Configuration {
   pub type_literal_separator_kind_single_line: SemiColonOrComma,
   #[serde(rename = "typeLiteral.separatorKind.multiLine")]
   pub type_literal_separator_kind_multi_line: SemiColonOrComma,
+  #[serde(rename = "multiLine.forceMultipleMultiLineSiblingsToUseMultiLines")]
+  pub multi_line_force_multiple_multi_line_siblings_to_use_multi_lines: bool,
   /* sorting */
   #[serde(rename = "module.sortImportDeclarations")]
   pub module_sort_import_declarations: SortOrder,
@@ -375,12 +377,19 @@ pub struct Configuration {
   pub try_statement_brace_position: BracePosition,
   #[serde(rename = "whileStatement.bracePosition")]
   pub while_statement_brace_position: BracePosition,
-  /* prefer hanging */
+  /* prefer hanging (with onlySingleItem option) */
   #[serde(rename = "arguments.preferHanging")]
   pub arguments_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayExpression.preferHanging")]
   pub array_expression_prefer_hanging: PreferHanging,
+  #[serde(rename = "parameters.preferHanging")]
+  pub parameters_prefer_hanging: PreferHanging,
+  #[serde(rename = "tupleType.preferHanging")]
+  pub tuple_type_prefer_hanging: PreferHanging,
+  #[serde(rename = "typeParameters.preferHanging")]
+  pub type_parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "arrayPattern.preferHanging")]
+  /* prefer hanging */
   pub array_pattern_prefer_hanging: bool,
   #[serde(rename = "doWhileStatement.preferHanging")]
   pub do_while_statement_prefer_hanging: bool,
@@ -406,18 +415,12 @@ pub struct Configuration {
   pub object_expression_prefer_hanging: bool,
   #[serde(rename = "objectPattern.preferHanging")]
   pub object_pattern_prefer_hanging: bool,
-  #[serde(rename = "parameters.preferHanging")]
-  pub parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "sequenceExpression.preferHanging")]
   pub sequence_expression_prefer_hanging: bool,
   #[serde(rename = "switchStatement.preferHanging")]
   pub switch_statement_prefer_hanging: bool,
-  #[serde(rename = "tupleType.preferHanging")]
-  pub tuple_type_prefer_hanging: PreferHanging,
   #[serde(rename = "typeLiteral.preferHanging")]
   pub type_literal_prefer_hanging: bool,
-  #[serde(rename = "typeParameters.preferHanging")]
-  pub type_parameters_prefer_hanging: PreferHanging,
   #[serde(rename = "unionAndIntersectionType.preferHanging")]
   pub union_and_intersection_type_prefer_hanging: bool,
   #[serde(rename = "variableStatement.preferHanging")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -51,9 +51,9 @@ fn gen_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItems {
 
 fn gen_node_with_inner_gen<'a>(node: Node<'a>, context: &mut Context<'a>, inner_gen: impl FnOnce(PrintItems, &mut Context<'a>) -> PrintItems) -> PrintItems {
   let node_kind = node.kind();
-  println!("Node kind: {:?}", node_kind);
-  println!("Text: {:?}", node.text());
-  println!("Range: {:?}", node.range());
+  // println!("Node kind: {:?}", node_kind);
+  // println!("Text: {:?}", node.text());
+  // println!("Range: {:?}", node.range());
 
   // store info
   let past_current_node = std::mem::replace(&mut context.current_node, node);
@@ -2775,10 +2775,7 @@ fn gen_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> PrintI
   gen_separated_values(
     GenSeparatedValuesParams {
       nodes: node.exprs.iter().map(|x| NodeOrSeparator::Node(x.into())).collect(),
-      prefer_hanging: match context.config.sequence_expression_prefer_hanging {
-        true => PreferHanging::Always,
-        false => PreferHanging::Never,
-      },
+      prefer_hanging: context.config.sequence_expression_prefer_hanging,
       force_use_new_lines: false,
       allow_blank_lines: false,
       separator: TrailingCommas::Never.into(),
@@ -3642,10 +3639,7 @@ fn gen_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Contex
     items.extend(gen_separated_values(
       GenSeparatedValuesParams {
         nodes: node.attrs.iter().map(|p| NodeOrSeparator::Node(p.into())).collect(),
-        prefer_hanging: match context.config.jsx_attributes_prefer_hanging {
-        true => PreferHanging::Always,
-        false => PreferHanging::Never,
-      },
+        prefer_hanging: context.config.jsx_attributes_prefer_hanging,
         force_use_new_lines,
         allow_blank_lines: false,
         separator: Separator::none(),
@@ -5126,10 +5120,7 @@ fn gen_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItems 
     items.extend(gen_separated_values(
       GenSeparatedValuesParams {
         nodes: node.decls.iter().map(|&p| NodeOrSeparator::Node(p.into())).collect(),
-        prefer_hanging: match context.config.variable_statement_prefer_hanging {
-        true => PreferHanging::Always,
-        false => PreferHanging::Never,
-      },
+        prefer_hanging: context.config.variable_statement_prefer_hanging,
         force_use_new_lines,
         allow_blank_lines: false,
         separator: TrailingCommas::Never.into(),
@@ -5853,9 +5844,14 @@ fn gen_type_parameters<'a>(node: TypeParamNode<'a>, context: &mut Context<'a>) -
   let params = node.params();
   let force_use_new_lines = get_use_new_lines(&node, &params, context);
   let mut items = PrintItems::new();
-  let prefer_hanging = context.config.type_parameters_prefer_hanging;
+  let prefer_hanging_config = context.config.type_parameters_prefer_hanging;
   let is_only_single_item_and_no_comments =
     only_single_item_and_no_comments(&params, node.tokens_fast(context.program).last(), context);
+  let prefer_hanging = match prefer_hanging_config {
+    PreferHanging::Never => false,
+    PreferHanging::OnlySingleItem => is_only_single_item_and_no_comments,
+    PreferHanging::Always => true,
+  };
 
   items.push_str("<");
   items.extend(gen_separated_values(
@@ -6605,7 +6601,7 @@ fn gen_array_like_nodes<'a>(opts: GenArrayLikeNodesOptions<'a>, context: &mut Co
       gen_separated_values(
         GenSeparatedValuesParams {
           nodes,
-          prefer_hanging: if prefer_hanging {PreferHanging::Always} else {PreferHanging::Never},
+          prefer_hanging,
           force_use_new_lines,
           allow_blank_lines: true,
           separator: trailing_commas.into(),
@@ -7083,7 +7079,7 @@ where
         items.extend(gen_separated_values(
           GenSeparatedValuesParams {
             nodes: nodes.into_iter().map(NodeOrSeparator::Node).collect(),
-            prefer_hanging: if prefer_hanging {PreferHanging::Always} else {PreferHanging::Never},
+            prefer_hanging,
             force_use_new_lines,
             allow_blank_lines: false,
             separator: trailing_commas.into(),
@@ -7293,7 +7289,7 @@ impl From<TrailingCommas> for Separator {
 
 struct GenSeparatedValuesParams<'a> {
   nodes: Vec<NodeOrSeparator<'a>>,
-  prefer_hanging: PreferHanging,
+  prefer_hanging: bool,
   force_use_new_lines: bool,
   allow_blank_lines: bool,
   separator: Separator,
@@ -7361,14 +7357,13 @@ fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, cont
       let sorted_indexes = node_sorter.map(|sorter| get_sorted_indexes(nodes.iter().map(|d| d.as_node()), sorter, context));
 
       for (i, value) in nodes.into_iter().enumerate() {
-        let has_siblings = nodes_count > 1;
         let node_index = match &sorted_indexes {
           Some(old_to_new_index) => *old_to_new_index.get(i).unwrap(),
           None => i,
         };
         let (allow_inline_multi_line, allow_inline_single_line) = if let NodeOrSeparator::Node(value) = value {
           let is_last_value = node_index + 1 == nodes_count; // allow the last node to be single line
-          (allows_inline_multi_line(value, context, has_siblings), is_last_value)
+          (allows_inline_multi_line(value, context, nodes_count > 1), is_last_value)
         } else {
           (false, false)
         };
@@ -7403,20 +7398,13 @@ fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, cont
           }
         };
 
-        // If we prefer hanging for a single item only, we omit the new_line_group to allow the single item to break up.
-        // E.g. with prefer_hanging true:
-        // |··functionCall(new Breakable(he, he));
-        // might break to
-        // |··functionCall(new······| <-- line break width
-        // |····Breakable(he, he));·| 
-        let use_new_line_group = if opts.prefer_hanging == PreferHanging::OnlySingleItem && !has_siblings
-        {
-          match value {
-          // Prefer going inline multi-line for certain expressions in arguments when initially single line.
+        let use_new_line_group = match value {
+          // Prefer going inline multi-line for certain expressions in arguments
+          // when initially single line.
           // Example: call({\n}) instead of call(\n  {\n  }\n)
           NodeOrSeparator::Node(Node::ExprOrSpread(expr_or_spread)) => !matches!(expr_or_spread.expr, Expr::Object(_) | Expr::Array(_)),
           _ => true,
-        }} else { false };
+        };
 
         generated_nodes.push(ir_helpers::GeneratedValue {
           items: if use_new_line_group { ir_helpers::new_line_group(items) } else { items },
@@ -7432,7 +7420,7 @@ fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, cont
       }
     },
     ir_helpers::GenSeparatedValuesOptions {
-      prefer_hanging: opts.prefer_hanging != PreferHanging::Always,
+      prefer_hanging: opts.prefer_hanging,
       force_use_new_lines: opts.force_use_new_lines,
       allow_blank_lines: opts.allow_blank_lines,
       single_line_space_at_start: opts.single_line_space_at_start,
@@ -7680,7 +7668,7 @@ fn gen_extends_or_implements<'a>(opts: GenExtendsOrImplementsOptions<'a>, contex
     items.extend(gen_separated_values(
       GenSeparatedValuesParams {
         nodes: opts.type_items.into_iter().map(NodeOrSeparator::Node).collect(),
-        prefer_hanging: if opts.prefer_hanging {PreferHanging::Always} else {PreferHanging::Never},
+        prefer_hanging: opts.prefer_hanging,
         force_use_new_lines: false,
         allow_blank_lines: false,
         separator: TrailingCommas::Never.into(),
@@ -7734,7 +7722,7 @@ fn gen_object_like_node<'a>(opts: GenObjectLikeNodeOptions<'a>, context: &mut Co
         gen_separated_values(
           GenSeparatedValuesParams {
             nodes: opts.members.into_iter().map(NodeOrSeparator::Node).collect(),
-            prefer_hanging: if opts.prefer_hanging {PreferHanging::Always} else {PreferHanging::Never},
+            prefer_hanging: opts.prefer_hanging,
             force_use_new_lines: force_multi_line,
             allow_blank_lines: opts.allow_blank_lines,
             separator: opts.separator,
@@ -7940,7 +7928,7 @@ fn gen_decorators<'a>(decorators: &[&'a Decorator<'a>], is_inline: bool, context
   let separated_values_result = gen_separated_values_with_result(
     GenSeparatedValuesParams {
       nodes: decorators.iter().map(|&p| NodeOrSeparator::Node(p.into())).collect(),
-      prefer_hanging: PreferHanging::Never, // would need to think about the design because prefer_hanging causes a hanging indent
+      prefer_hanging: false, // would need to think about the design because prefer_hanging causes a hanging indent
       force_use_new_lines,
       allow_blank_lines: false,
       separator: Separator::none(),
@@ -9162,8 +9150,6 @@ fn allows_inline_multi_line(node: Node, context: &Context, has_siblings: bool) -
           _ => allows_inline_multi_line(as_expr.type_ann.into(), context, has_siblings),
         }
     }
-    // Only allow inline multline for functions / arrow expressions if none of the
-    // siblings are also functions or arrow expressions.
     Node::FnExpr(_)
     | Node::ArrowExpr(_)
     | Node::ObjectLit(_)

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7016,7 +7016,6 @@ where
 {
   let nodes = opts.nodes;
   let is_parameters = opts.is_parameters;
-
   let prefer_hanging_config = if is_parameters {
     context.config.parameters_prefer_hanging
   } else {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7025,14 +7025,14 @@ where
     PreferHanging::OnlySingleItem => is_only_single_item_and_no_comments,
     PreferHanging::Always => true,
   };
-  let multi_line_options = if prefer_hanging_config == PreferHanging::OnlySingleItem && nodes.len() == 1 {
+  let prefer_single_item_hanging = prefer_hanging_config == PreferHanging::OnlySingleItem && is_only_single_item_and_no_comments;
+  let multi_line_options = if prefer_single_item_hanging {
     MultiLineOptions::maintain_line_breaks()
   } else {
     MultiLineOptions::surround_newlines_indented()
   };
 
-  let is_single_item_hanging = prefer_hanging_config == PreferHanging::OnlySingleItem && is_only_single_item_and_no_comments;
-  let prefer_single_line = is_single_item_hanging || (
+  let prefer_single_line = prefer_single_item_hanging || (
     is_parameters && context.config.parameters_prefer_single_line || !is_parameters && context.config.arguments_prefer_single_line
   );
   let force_use_new_lines = get_use_new_lines_for_nodes_with_preceeding_token("(", &nodes, prefer_single_line, context);

--- a/tests/specs/declarations/class/method/ClassMethod_PreferHanging_True.txt
+++ b/tests/specs/declarations/class/method/ClassMethod_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 50 ~~
+~~ parameters.preferHanging: always, lineWidth: 50 ~~
 == should format the return type on the same line when the rest of the header is hanging ==
 class Test {
     method(param: string, otherTestinginging: string): test | other {

--- a/tests/specs/declarations/function/Function_BracePosition_Maintain.txt
+++ b/tests/specs/declarations/function/Function_BracePosition_Maintain.txt
@@ -1,4 +1,4 @@
-~~ functionDeclaration.bracePosition: maintain, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ functionDeclaration.bracePosition: maintain, parameters.preferHanging: always, lineWidth: 30 ~~
 == should maintain the position for the brace position when on same line ==
 function t() {
 }

--- a/tests/specs/declarations/function/Function_BracePosition_NextLine.txt
+++ b/tests/specs/declarations/function/Function_BracePosition_NextLine.txt
@@ -1,4 +1,4 @@
-~~ functionDeclaration.bracePosition: nextLine, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ functionDeclaration.bracePosition: nextLine, parameters.preferHanging: always, lineWidth: 30 ~~
 == should use the next line for the brace position ==
 function t() {
 }

--- a/tests/specs/declarations/function/Function_BracePosition_SameLine.txt
+++ b/tests/specs/declarations/function/Function_BracePosition_SameLine.txt
@@ -1,4 +1,4 @@
-~~ functionDeclaration.bracePosition: sameLine, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ functionDeclaration.bracePosition: sameLine, parameters.preferHanging: always, lineWidth: 30 ~~
 == should use the same line for the brace position ==
 function t()
 {

--- a/tests/specs/declarations/function/Function_CloseBraceOverMaxWidth.txt
+++ b/tests/specs/declarations/function/Function_CloseBraceOverMaxWidth.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 80, parameters.preferHanging: true ~~
+~~ lineWidth: 80, parameters.preferHanging: always ~~
 == Brace at 79 ==
 export function test(some, very, long, list, of, params, to, put, brace, over) {
 }

--- a/tests/specs/declarations/function/Function_PreferHanging_True.txt
+++ b/tests/specs/declarations/function/Function_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format params with a hanging indent ==
 function test(here, are, some, parens, thatGoLong) {
 }

--- a/tests/specs/declarations/interface/callSignature/CallSignature_PreferHanging_True.txt
+++ b/tests/specs/declarations/interface/callSignature/CallSignature_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format the return type on the same line when the rest of the header is hanging ==
 interface T {
     (param: string, otherTesting: string): te | st;

--- a/tests/specs/declarations/interface/constructSignature/ConstructSignature_PreferHanging_True.txt
+++ b/tests/specs/declarations/interface/constructSignature/ConstructSignature_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format the return type on the same line when the rest of the header is hanging ==
 interface T {
     new (param: string, otherTest: string): te | st;

--- a/tests/specs/declarations/interface/methodSignature/MethodSignature_PreferHanging_True.txt
+++ b/tests/specs/declarations/interface/methodSignature/MethodSignature_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format the return type on the same line when the rest of the header is hanging ==
 interface T {
     method(param: string, otherTest: string): test | ing;

--- a/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferHanging_Always.txt
+++ b/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, arrayExpression.preferHanging: true ~~
+~~ lineWidth: 40, arrayExpression.preferHanging: always ~~
 == should format ==
 const t = [   5   , 6   ];
 

--- a/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_Maintain.txt
+++ b/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_Maintain.txt
@@ -1,4 +1,4 @@
-~~ arrowFunction.bracePosition: maintain, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ arrowFunction.bracePosition: maintain, parameters.preferHanging: always, lineWidth: 30 ~~
 == should maintain the position for the brace position when on same line ==
 const t = () => {
 };

--- a/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_NextLine.txt
+++ b/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_NextLine.txt
@@ -1,4 +1,4 @@
-~~ arrowFunction.bracePosition: nextLine, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ arrowFunction.bracePosition: nextLine, parameters.preferHanging: always, lineWidth: 30 ~~
 == should use the next line for the brace position ==
 const t = () => {
 };

--- a/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_SameLine.txt
+++ b/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_BracePosition_SameLine.txt
@@ -1,4 +1,4 @@
-~~ arrowFunction.bracePosition: sameLine, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ arrowFunction.bracePosition: sameLine, parameters.preferHanging: always, lineWidth: 30 ~~
 == should use the same line for the brace position ==
 const t = () =>
 {

--- a/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_PreferHanging_Always.txt
+++ b/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 80 ~~
+~~ parameters.preferHanging: always, lineWidth: 80 ~~
 == should format params with a hanging indent by default ==
 const t = (here, are, some, parens, that, will, go, over, the, limit, off, width, source, file) => {
 }

--- a/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_PreferHanging_Never.txt
+++ b/tests/specs/expressions/ArrowFunctionExpression/ArrowFunctionExpression_PreferHanging_Never.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: false, lineWidth: 40 ~~
+~~ parameters.preferHanging: never, lineWidth: 40 ~~
 == should force multi-line parameters when exceeding the line width ==
 const t = (testing, thisOut, byExceeding, theLineWidth) => "";
 

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Always.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferHanging: true, lineWidth: 40 ~~
+~~ arguments.preferHanging: always, lineWidth: 40 ~~
 == should force multi-line arguments when exceeding the line width ==
 call(testing, thisOut, byExceeding, theLineWidth);
 

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Never.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Never.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferHanging: false, lineWidth: 40 ~~
+~~ arguments.preferHanging: never, lineWidth: 40 ~~
 == should force multi-line arguments when exceeding the line width ==
 call(testing, thisOut, byExceeding, theLineWidth);
 

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
@@ -9,8 +9,15 @@ call(new Foo({
     baz: "c",
 }));
 
+== should use hanging indentation for nested single items, even over the line width ==
+call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
+
+[expect]
+call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
+
 == should use multi-line indentation if there are multiple items ==
 call(new Foo({ test: "a", }), new Bar(), baz);
+call(sub_call_we_want_to_hang(multi_line_me_bro, yeah_cmon));
 
 [expect]
 call(
@@ -18,3 +25,7 @@ call(
     new Bar(),
     baz,
 );
+call(sub_call_we_want_to_hang(
+    multi_line_me_bro,
+    yeah_cmon,
+));

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
@@ -10,9 +10,11 @@ call(new Foo({
 }));
 
 == should use hanging indentation for nested single items, even over the line width ==
+call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
 call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
 
 [expect]
+call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
 call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
 
 == should use multi-line indentation if there are multiple items ==

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
@@ -1,0 +1,91 @@
+~~ arguments.preferHanging: onlySingleItem, multiLine.forceMultipleMultiLineSiblingsToUseMultiLines: true, lineWidth: 40 ~~
+== should use hanging indentation for a single item ==
+call(new Foo({ test: "a", bar: "b", baz: "c" }));
+
+[expect]
+call(new Foo({
+    test: "a",
+    bar: "b",
+    baz: "c",
+}));
+
+== should use multi-line indentation if there are multiple items ==
+call(new Foo({ test: "a", }), new Bar(), baz);
+
+[expect]
+call(
+    new Foo({ test: "a" }),
+    new Bar(),
+    baz,
+);
+
+== should use multi-line indentation if there is a leading comment, even for a single item ==
+fetchMock.mockResponses(
+    // getVideoFileUrl
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+);
+
+[expect]
+fetchMock.mockResponses(
+    // getVideoFileUrl
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+);
+
+== should use multi-line indentation if there is a trailing comment, even for a single item ==
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+    // getVideoFileUrl
+);
+
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ], // getVideoFileUrl
+);
+
+[expect]
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+    // getVideoFileUrl
+);
+
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ], // getVideoFileUrl
+);
+
+== should use hanging indentation if the first argument is an arrow function, and the second argument is not ==
+setTimeout(() => {
+someBody;
+}, 500);
+
+[expect]
+setTimeout(() => {
+    someBody;
+}, 500);
+
+== should use multi-line indentation if there are multiple arrow function arguments ==
+reaction(() => { console.log("a"); }, () => b);
+
+[expect]
+reaction(
+    () => {
+        console.log("a");
+    },
+    () => b,
+);

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
@@ -31,3 +31,53 @@ call(sub_call_we_want_to_hang(
     multi_line_me_bro,
     yeah_cmon,
 ));
+
+== should use multi-line indentation if there is a leading comment, even for a single item ==
+fetchMock.mockResponses(
+    // getVideoFileUrl
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+);
+
+[expect]
+fetchMock.mockResponses(
+    // getVideoFileUrl
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+);
+
+== should use multi-line indentation if there is a trailing comment, even for a single item ==
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+    // getVideoFileUrl
+);
+
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ], // getVideoFileUrl
+);
+
+[expect]
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ],
+    // getVideoFileUrl
+);
+
+fetchMock.mockResponses(
+    [
+        "Forbidden",
+        { status: 403 },
+    ], // getVideoFileUrl
+);

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_OnlySingleItem.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferHanging: onlySingleItem, multiLine.forceMultipleMultiLineSiblingsToUseMultiLines: true, lineWidth: 40 ~~
+~~ arguments.preferHanging: onlySingleItem, lineWidth: 40 ~~
 == should use hanging indentation for a single item ==
 call(new Foo({ test: "a", bar: "b", baz: "c" }));
 
@@ -17,75 +17,4 @@ call(
     new Foo({ test: "a" }),
     new Bar(),
     baz,
-);
-
-== should use multi-line indentation if there is a leading comment, even for a single item ==
-fetchMock.mockResponses(
-    // getVideoFileUrl
-    [
-        "Forbidden",
-        { status: 403 },
-    ],
-);
-
-[expect]
-fetchMock.mockResponses(
-    // getVideoFileUrl
-    [
-        "Forbidden",
-        { status: 403 },
-    ],
-);
-
-== should use multi-line indentation if there is a trailing comment, even for a single item ==
-fetchMock.mockResponses(
-    [
-        "Forbidden",
-        { status: 403 },
-    ],
-    // getVideoFileUrl
-);
-
-fetchMock.mockResponses(
-    [
-        "Forbidden",
-        { status: 403 },
-    ], // getVideoFileUrl
-);
-
-[expect]
-fetchMock.mockResponses(
-    [
-        "Forbidden",
-        { status: 403 },
-    ],
-    // getVideoFileUrl
-);
-
-fetchMock.mockResponses(
-    [
-        "Forbidden",
-        { status: 403 },
-    ], // getVideoFileUrl
-);
-
-== should use hanging indentation if the first argument is an arrow function, and the second argument is not ==
-setTimeout(() => {
-someBody;
-}, 500);
-
-[expect]
-setTimeout(() => {
-    someBody;
-}, 500);
-
-== should use multi-line indentation if there are multiple arrow function arguments ==
-reaction(() => { console.log("a"); }, () => b);
-
-[expect]
-reaction(
-    () => {
-        console.log("a");
-    },
-    () => b,
 );

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_True.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_True.txt
@@ -5,3 +5,21 @@ call(testing, thisOut, byExceeding, theLineWidth);
 [expect]
 call(testing, thisOut, byExceeding,
     theLineWidth);
+
+== should force multi-line when exceeding the line width, even when there's only a single argument ==
+call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
+call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
+
+[expect]
+call(
+    big_long_single_argument_cannot_be_broken_so_gets_multilined,
+);
+call(
+    sub_call_1(
+        subcall_2(
+            subcall_3(
+                "we're past column 40",
+            ),
+        ),
+    ),
+);

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_Maintain.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_Maintain.txt
@@ -1,4 +1,4 @@
-~~ functionExpression.bracePosition: maintain, parameters.preferHanging: true, lineWidth: 30 ~~
+~~ functionExpression.bracePosition: maintain, parameters.preferHanging: always, lineWidth: 30 ~~
 == should maintain the position for the brace position when on same line ==
 const t = function t() {
 };

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_NextLine.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_NextLine.txt
@@ -1,4 +1,4 @@
-~~ functionExpression.bracePosition: nextLine, parameters.preferHanging: true, lineWidth: 35 ~~
+~~ functionExpression.bracePosition: nextLine, parameters.preferHanging: always, lineWidth: 35 ~~
 == should use the next line for the brace position ==
 const t = function() {
 };

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_SameLine.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_BracePosition_SameLine.txt
@@ -1,4 +1,4 @@
-~~ functionExpression.bracePosition: sameLine, parameters.preferHanging: true, lineWidth: 35 ~~
+~~ functionExpression.bracePosition: sameLine, parameters.preferHanging: always, lineWidth: 35 ~~
 == should use the same line for the brace position ==
 const t = function()
 {

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_PreferHanging_Always.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 80, parameters.preferHanging: true ~~
+~~ lineWidth: 80, parameters.preferHanging: always ~~
 == should format params with a hanging indent ==
 const t = function(here, are, some, parens, that, will, go, over, the, limit, of, width, source, file) {
 }

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_PreferHanging_Never.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_PreferHanging_Never.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: false, lineWidth: 40 ~~
+~~ parameters.preferHanging: never, lineWidth: 40 ~~
 == should force multi-line parameters when exceeding the line width ==
 const t = function(testing, thisOut, byExceeding, theLineWidth) {
 };

--- a/tests/specs/expressions/NewExpression/NewExpression_PreferHanging_Never.txt
+++ b/tests/specs/expressions/NewExpression/NewExpression_PreferHanging_Never.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferHanging: false, lineWidth: 40 ~~
+~~ arguments.preferHanging: never, lineWidth: 40 ~~
 == should force multi-line arguments when exceeding the line width ==
 const t = new Class(testing, thisOut, byExceeding, theLineWidth);
 

--- a/tests/specs/expressions/ObjectMethod/ObjectMethod_PreferHanging_Always.txt
+++ b/tests/specs/expressions/ObjectMethod/ObjectMethod_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 50 ~~
+~~ parameters.preferHanging: always, lineWidth: 50 ~~
 == should format the return type on the same line when the rest of the header is hanging ==
 const obj = {
     method(param: string, otherTestinginging: string): test | other {

--- a/tests/specs/general/Arguments_PreferHanging_True.txt
+++ b/tests/specs/general/Arguments_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 80, arguments.preferHanging: true ~~
+~~ lineWidth: 80, arguments.preferHanging: always ~~
 == should use the parenthesis before the argument for deciding whether to use multiple lines ==
 function test() {
     call(fileNames).then(() => {

--- a/tests/specs/general/Arguments_PreferSingleLine_PreferHanging_True.txt
+++ b/tests/specs/general/Arguments_PreferSingleLine_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferSingleLine: true, arguments.preferHanging: true, lineWidth: 40 ~~
+~~ arguments.preferSingleLine: true, arguments.preferHanging: always, lineWidth: 40 ~~
 == should not keep multi-line when multi-line and below the line width ==
 call(
     testing,

--- a/tests/specs/general/Parameters_PreferHanging_True.txt
+++ b/tests/specs/general/Parameters_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 60, parameters.preferHanging: true ~~
+~~ lineWidth: 60, parameters.preferHanging: always ~~
 == should not split up within a parameter that exceeds the line width ==
 export function test(param1: string, param2: number, t: string) {
 }

--- a/tests/specs/issues/old-repo/issue028.txt
+++ b/tests/specs/issues/old-repo/issue028.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 80, arguments.preferHanging: false, quoteStyle: alwaysSingle ~~
+~~ lineWidth: 80, arguments.preferHanging: never, quoteStyle: alwaysSingle ~~
 == should format ==
 export class Testing {
     constructor() {

--- a/tests/specs/issues/old-repo/issue035.txt
+++ b/tests/specs/issues/old-repo/issue035.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, arguments.preferHanging: true ~~
+~~ lineWidth: 40, arguments.preferHanging: always ~~
 == should not throw error about finishIndent being called without a corresponding startIndent (skip-format-twice) ==
 // skip format twice because preferSingleLine is false
 t(u, tbdstdddddbbSftt ? dddddmdd : testt);

--- a/tests/specs/issues/old-repo/issue035_PreferSingleLine.txt
+++ b/tests/specs/issues/old-repo/issue035_PreferSingleLine.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, arguments.preferHanging: true, preferSingleLine: true ~~
+~~ lineWidth: 40, arguments.preferHanging: always, preferSingleLine: true ~~
 == should not throw error about finishIndent being called without a corresponding startIndent ==
 t(u, tbdstdddddbbSftt ? dddddmdd : testt);
 

--- a/tests/specs/issues/old-repo/issue036.txt
+++ b/tests/specs/issues/old-repo/issue036.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 120, arguments.preferHanging: true ~~
+~~ lineWidth: 120, arguments.preferHanging: always ~~
 == should format ==
 namespace test.something {
     function test() {

--- a/tests/specs/issues/old-repo/issue084.txt
+++ b/tests/specs/issues/old-repo/issue084.txt
@@ -1,4 +1,4 @@
-~~ arguments.preferHanging: true ~~
+~~ arguments.preferHanging: always ~~
 == should format ==
 it("should get the class descendants", () => {
     doTest("class Base {} class Child1 extends Base {} class Child2 extends Base {} class Grandchild1<T> extends Child1 {} class GreatGrandChild1<T> extends Grandchild1<T> {}",

--- a/tests/specs/types/ConstructorType/ConstructorType_PreferHanging_True.txt
+++ b/tests/specs/types/ConstructorType/ConstructorType_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format the params as multi-line when the return type exceeds the line width ==
 type Test = new (param: string) => str | number;
 

--- a/tests/specs/types/FunctionType/FunctionType_PreferHanging_True.txt
+++ b/tests/specs/types/FunctionType/FunctionType_PreferHanging_True.txt
@@ -1,4 +1,4 @@
-~~ parameters.preferHanging: true, lineWidth: 40 ~~
+~~ parameters.preferHanging: always, lineWidth: 40 ~~
 == should format the params as multi-line when the return type exceeds the line width ==
 type Test = (param: string) => str | number;
 

--- a/tests/specs/types/TupleType/TupleType_PreferHanging_Always.txt
+++ b/tests/specs/types/TupleType/TupleType_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, tupleType.preferHanging: true ~~
+~~ lineWidth: 40, tupleType.preferHanging: always ~~
 == should format ==
 type T = [   string   , number   ];
 

--- a/tests/specs/types/TypeParameter/TypeParameter_PreferHanging_Always.txt
+++ b/tests/specs/types/TypeParameter/TypeParameter_PreferHanging_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, typeParameters.preferHanging: true ~~
+~~ lineWidth: 40, typeParameters.preferHanging: always ~~
 == should not break up the middle of a type parameter ==
 class Test<T, TestingThisOut extends number> {
 }


### PR DESCRIPTION
# Before

`preferHanging` for "separated values" (parameters, arrays, tuples, objects, etc.) only accepted true or false. For single values, `true` produced multi-lining that felt overly verbose. For example, the parameters inside a call expression were either all hanging or on their own line:

```
~~ arguments.preferHanging: true, lineWidth: 40 ~~
== verbose, uses lots of space for single items ==
call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));

[expect]
call(
    big_long_single_argument_cannot_be_broken_so_gets_multilined,
);
call(
    sub_call_1(
        subcall_2(
            subcall_3(
                "we're past column 40",
            ),
        ),
    ),
);
```

Using `false` would mean that multiple values (like objects) couldn't benefit from multiline.

# Changes

For the above reasons, we've added `preferHanging: onlySingleItem`, which allows us to prefer hanging only if there is a single item in the list of separated values. We think this looks much cleaner.

This change is backwards compatible. `parameters.preferHanging: true` in a config file will be parsed to `config.parameters_prefer_hanging: PreferHanging::Always`.

```
~~ arguments.preferHanging: onlySingleItem, lineWidth: 40 ~~
== should use hanging indentation for nested single items, even over the line width ==
call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
call(multiple_arguments, still_get_multilined, if_they_exceed_line_width);

[expect]
call(big_long_single_argument_cannot_be_broken_so_gets_multilined);
call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
call(
  multiple_arguments,
  still_get_multilined,
  if_they_exceed_line_width,
);
```