### PR TITLE
arguments.singleLambdaTrailingComma: bool

### DIFF
--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -92,6 +92,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     quote_props,
     semi_colons,
     /* situational */
+    arguments_single_lambda_should_have_trailing_comma: get_value(&mut config, "arguments.singleLambdaTrailingComma", false, &mut diagnostics),
     arrow_function_use_parentheses: get_value(&mut config, "arrowFunction.useParentheses", UseParentheses::Maintain, &mut diagnostics),
     binary_expression_line_per_expression: get_value(&mut config, "binaryExpression.linePerExpression", false, &mut diagnostics),
     conditional_expression_line_per_expression: get_value(&mut config, "conditionalExpression.linePerExpression", true, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -277,6 +277,8 @@ pub struct Configuration {
   pub quote_props: QuoteProps,
   pub semi_colons: SemiColons,
   /* situational */
+  #[serde(rename = "arguments.singleLambdaTrailingComma")]
+  pub arguments_single_lambda_should_have_trailing_comma: bool,
   #[serde(rename = "arrowFunction.useParentheses")]
   pub arrow_function_use_parentheses: UseParentheses,
   #[serde(rename = "binaryExpression.linePerExpression")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7033,6 +7033,9 @@ where
         items.push_info(start_lsil);
         items.push_signal(Signal::PossibleNewLine);
         items.push_condition(conditions::indent_if_start_of_line(generated_node));
+        if context.config.arguments_single_lambda_should_have_trailing_comma {
+          items.push_str(",");
+        }
         items.push_condition(if_true(
           "isDifferentLineAndStartLineIndentation",
           Rc::new(move |context| {

--- a/tests/specs/expressions/CallExpression/CallExpression_SingleLambdaTrailingComma_False.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_SingleLambdaTrailingComma_False.txt
@@ -1,0 +1,8 @@
+~~ lineWidth: 40, arguments.singleLambdaTrailingComma: true ~~
+== a single lambda argument should have a trailing comma (only) ==
+funkyFunctionCall(() => "a lambda that line breaks, hangs, and has a comma");
+
+[expect]
+funkyFunctionCall(() =>
+    "a lambda that line breaks, hangs, and has a comma",
+);

--- a/tests/specs/expressions/CallExpression/CallExpression_SingleLambdaTrailingComma_True.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_SingleLambdaTrailingComma_True.txt
@@ -1,0 +1,8 @@
+~~ lineWidth: 40, arguments.singleLambdaTrailingComma: false ~~
+== a single lambda argument should NOT have a trailing comma (only) ==
+funkyFunctionCall(() => "a lambda that line breaks, hangs, and has NO comma");
+
+[expect]
+funkyFunctionCall(() =>
+    "a lambda that line breaks, hangs, and has NO comma"
+);


### PR DESCRIPTION
# Problem

There is [a special edge case for formatting a function](https://github.com/dprint/dprint-plugin-typescript/blob/786c790205cdea3f7160d63f83d2ec667c5a04f6/src/generation/generate.rs#L7067) when
1. The function has a single argument; and
2. The single argument is a lambda function e.g .`() => "sheep"`

An example of this special case currently looks like this after formatting:

```
funkyFunctionCall(() =>
    "a lambda that line breaks, hangs, and has NO comma"
);
```

If a single-argument function with a lambda someday evolves into a grown-up multi-argument function, it's mildly annoying to have to add a comma to the existing argument line.

```diff
funkyFunctionCall(() =>
-    "a lambda that line breaks, hangs, and has NO comma"
+    "a lambda that line breaks, hangs, and has NO comma",
+    theNewArgument,
);
```

# Solution

I've added a situational boolean for this special edge case.

```
~~ lineWidth: 40, arguments.singleLambdaTrailingComma: true ~~
== a single lambda argument should have a trailing comma (only) ==
funkyFunctionCall(() => "a lambda that line breaks, hangs, and has a comma");

[expect]
funkyFunctionCall(() =>
    "a lambda that line breaks, hangs, and has a comma",
);
```

Now if we added an extra argument to the `funkyFunctionCall` function, the diff would look like this:

```diff
funkyFunctionCall(() =>
      "a lambda that line breaks, hangs, and has a comma",
+    theNewArgument,
);
```