### PR TITLE
Add dprint executable for development

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,28 @@
+# How to test your plugin's changes on real files
+
+You've made some changes to this repo on your local machine, and now you probably want to test it against your own project repo.
+
+The `dprint` script in this folder is a convenient wrapper that makes it easy to build and call your work-in-progress dprint and plugins from anywhere on your system. It will always rebuild dprint and the typescript plugin if necessary.
+
+To use it:
+1. In the `dprint` script, set `DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH` to wherever this repo is cloned. You can find that by running
+
+```sh
+git rev-parse --show-toplevel
+```
+
+2. If you have your own `dprint.json` config, then inside the `dprint.json` in this `development` folder, change the `extends` field to the absolute path of your `dprint.json`. For example, if my project repo filetree looks like the following, then I would specify `extends: "/Users/david/work/my-project/dprint.json"`.
+
+```
+/
+└--_ Users
+   └--_ david
+      └--_ work
+         |--  dprint-plugin-typescript
+         └--_ my-project
+            |--  dprint.json
+            └--_ src
+               | ...
+```
+
+3. Run the `dprint` script inside this folder.

--- a/development/dprint
+++ b/development/dprint
@@ -1,0 +1,33 @@
+#!/bin/sh
+export DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH=$HOME/work/dprint-plugin-typescript/
+# Assumes you have set the DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH variable to declare where this repo is located.
+# This allows us to call the dprint binary from anywhere.
+if test ! -d $DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH;
+    then echo "The project folder for dprint-plugin-typescript could not be found. Please set the DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH variable inside \"dprint-plugin-typescript/development/dprint\" and try again."
+    exit -1
+fi
+# Assumes you have the wasm32-unknown-unknown target installed
+if test -z "$(rustup target list | grep -- "wasm32-unknown-unknown (installed)")";
+    then echo The "wasm32-unknown-unknown" target could not be found via "rustup". Please run "rustup install wasm32-unknown-unknown".
+    exit -1
+fi
+# Assumes you have dprint cloned under the dprint-plugin-typescript folder
+if test ! -d $DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH/dprint;
+    then echo dprint not found. Please run "git clone git@github.com:dprint/dprint.git" from the dprint-plugin-typescript folder.
+    exit -1
+fi
+
+# Build dprint-plugin-typescript and dprint
+cd $DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH
+cargo build --target wasm32-unknown-unknown --release --features "wasm"
+
+# Our local dprint binary
+export DPRINT=$DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH/dprint/target/debug/dprint
+# A config that loads our the typescript plugin built from this repo's source.
+# You can add your other configuration options by opening this file and changing
+# the "extends" field to your custom dprint.json file.
+export DPRINT_CONFIG=$DPRINT_PLUGIN_TYPESCRIPT_SOURCE_PATH/development/dprint.json
+
+# Run our local dprint.
+cd -;
+$DPRINT --config=$DPRINT_CONFIG $@


### PR DESCRIPTION
# Problem

When developing this plugin, it's often useful to test the diff a change will have on your own codebase. As an engineer at Canva, I'm adding features to `dprint-plugin-typescript` that help us implement our own style guide. To demonstrate that a feature satisfies our style guide, other engineers often want to see real world formatting examples in our own codebase.

Currently, to format our project's codebase with a work-in-progress feature branch on this repo, I need to
1. Manually rebuild the plugin (and `dprint-core` if necessary)
2. Call the resulting `dprint` executable with a config that specifies my freshly built Typescript plugin

# Changes

Adds a `development/dprint` script that rebuilds and executes dprint with a freshly built typescript plugin. It also adds documentation for using it. I hope that this wrapper script is helpful for others and encourages easier prototyping.

From my own project, I can now preview how my latest Typescript plugin changes will affect my project's codebase.

```sh
dprint_dev=$HOME/work/dprint-plugin-typescript/development/dprint
cd ~/my-project
dprint_dev fmt -- **/*.ts
```