### PR TITLE
Remove special case for single argument lambdas with an expression body

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -9149,16 +9149,6 @@ fn surround_with_parens(items: PrintItems) -> PrintItems {
 
 /* is/has functions */
 
-fn is_arrow_function_with_expr_body(node: Node) -> bool {
-  match node {
-    Node::ExprOrSpread(expr_or_spread) => match expr_or_spread.expr {
-      Expr::Arrow(arrow) => matches!(&arrow.body, BlockStmtOrExpr::Expr(_)),
-      _ => false,
-    },
-    _ => false,
-  }
-}
-
 fn allows_inline_multi_line(node: Node, context: &Context, has_siblings: bool) -> bool {
   return match node {
     Node::Param(param) => allows_inline_multi_line(param.pat.into(), context, has_siblings),

--- a/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Always.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_PreferHanging_Always.txt
@@ -14,12 +14,6 @@ call(sub_call_1(subcall_2(subcall_3("we're past column 40"))));
 call(
     big_long_single_argument_cannot_be_broken_so_gets_multilined,
 );
-call(
-    sub_call_1(
-        subcall_2(
-            subcall_3(
-                "we're past column 40",
-            ),
-        ),
-    ),
-);
+call(sub_call_1(subcall_2(subcall_3(
+    "we're past column 40",
+))));

--- a/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_Always.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_Always.txt
@@ -1,0 +1,17 @@
+~~ lineWidth: 40, arguments.trailingCommas: always ~~
+== a call expression in multi-line mode should have trailing commas after each argument ==
+functionCall(() => "a lambda", "a string", "over line break");
+
+[expect]
+functionCall(
+    () => "a lambda",
+    "a string",
+    "over line break",
+);
+
+== a call expression in hanging mode should have a trailing comma after its argument ==
+functionCall(() => "a long overflowing lambda");
+
+[expect]
+functionCall(() =>
+    "a long overflowing lambda",);

--- a/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_Never.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_Never.txt
@@ -1,0 +1,17 @@
+~~ lineWidth: 40, arguments.trailingCommas: never ~~
+== a call expression in multi-line mode should have trailing commas after each argument ==
+functionCall(() => "a lambda", "a string", "over line break");
+
+[expect]
+functionCall(
+    () => "a lambda",
+    "a string",
+    "over line break"
+);
+
+== a call expression in hanging mode should have a trailing comma after its argument ==
+functionCall(() => "a long overflowing lambda");
+
+[expect]
+functionCall(() =>
+    "a long overflowing lambda");

--- a/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_OnlyMultiLine.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_OnlyMultiLine.txt
@@ -9,6 +9,16 @@ functionCall(
     "over line break",
 );
 
+== a call expression in multi-line mode should have trailing commas after each argument, even for a single argument ==
+functionCall(
+    () => "a lambda",
+);
+
+[expect]
+functionCall(
+    () => "a lambda",
+);
+
 == a call expression in hanging mode should not have a trailing comma after its argument ==
 functionCall(() => "a long overflowing lambda");
 

--- a/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_OnlyMultiLine.txt
+++ b/tests/specs/expressions/CallExpression/CallExpression_TrailingCommas_OnlyMultiLine.txt
@@ -1,0 +1,17 @@
+~~ lineWidth: 40, arguments.trailingCommas: onlyMultiLine ~~
+== a call expression in multi-line mode should have trailing commas after each argument ==
+functionCall(() => "a lambda", "a string", "over line break");
+
+[expect]
+functionCall(
+    () => "a lambda",
+    "a string",
+    "over line break",
+);
+
+== a call expression in hanging mode should not have a trailing comma after its argument ==
+functionCall(() => "a long overflowing lambda");
+
+[expect]
+functionCall(() =>
+    "a long overflowing lambda");

--- a/tests/specs/issues/old-repo/issue105.txt
+++ b/tests/specs/issues/old-repo/issue105.txt
@@ -1,18 +1,4 @@
 ~~ lineWidth: 80, indentWidth: 2 ~~
-== should keep nested arrow functions on separate lines ==
-entitiesGroupOne.forEach((entity, indexOne) =>
-  entitiesGroupTwo.forEach((entityTwo, indexTwo) => {
-    call();
-  })
-);
-
-[expect]
-entitiesGroupOne.forEach((entity, indexOne) =>
-  entitiesGroupTwo.forEach((entityTwo, indexTwo) => {
-    call();
-  })
-);
-
 == should move short non-multi-line body back up to same line ==
 entitiesGroupOne.forEach((entity, indexOne) =>
     call()

--- a/tests/specs/issues/old-repo/issue165.txt
+++ b/tests/specs/issues/old-repo/issue165.txt
@@ -13,8 +13,7 @@ const initialFiles = await Promise.all(
         readFile(f.filePath).then(data => ({
             filePath: f.filePath,
             contents: data,
-        } as FileInfo))
-    ),
+        } as FileInfo))),
 );
 
 == should format as-is ==

--- a/tests/specs/jsx/JsxElement/JsxElement_MultiLineParens_Never.txt
+++ b/tests/specs/jsx/JsxElement/JsxElement_MultiLineParens_Never.txt
@@ -117,8 +117,6 @@ const u = test.map((a, b) => <testing a={b} b={test} />);
 const t = test.map((a, b) =>
     <testing a={b} b={test}>
         {a[1]}
-    </testing>
-);
+    </testing>);
 const u = test.map((a, b) =>
-    <testing a={b} b={test} />
-);
+    <testing a={b} b={test} />);


### PR DESCRIPTION
# Problem

There is [a special edge case for formatting a function](https://github.com/dprint/dprint-plugin-typescript/blob/786c790205cdea3f7160d63f83d2ec667c5a04f6/src/generation/generate.rs#L7067) when
1. The function has a single argument; and
2. The single argument is a lambda function e.g .`() => "sheep"`

However, this means that this edge case ignores `arguments.*` preferences such as `arguments.trailingCommas`. Note that the call expression is multi-line in this example because by default the TS dprint plugin preserves existing newlines after the `(`.

## `arguments.trailingCommas`

```
~~ lineWidth: 40, arguments.trailingCommas: onlyMultiLine ~~
== a call expression in multi-line mode should have trailing commas after each argument, even for a single argument ==
functionCall(
    () => "a lambda",
);

[expect]
functionCall(
    () => "a lambda"      <-- incorrect, missing trailing comma
);

```

## `arguments.preferHanging: always`

```
~~ lineWidth: 40, arguments.preferHanging: always ~~
== a call expression should format in hanging mode ==
functionCall(
    () => "a lambda",
);

[expect]
functionCall(() => 
    "a lambda"      <-- incorrect, neither hanging nor multi-line
);

```

# Changes

1. Remove the [special edge case](https://github.com/dprint/dprint-plugin-typescript/pull/489/files#diff-006be3bb05abfb2221b2909f0e968999c52012e8c7eb6a6ed245df44238d18b6L7067) for call expressions with a single argument lambda with an expression body.
2. [Permit hanging mode for arrow functions](https://github.com/dprint/dprint-plugin-typescript/pull/489/files#diff-006be3bb05abfb2221b2909f0e968999c52012e8c7eb6a6ed245df44238d18b6R7410) and a variety of other expressions inside hanging call expressions. I believe this block of code is where the aforementioned special case should have gone.
3. Add [some tests](https://github.com/dprint/dprint-plugin-typescript/pull/489/files#diff-af646318d85e65aab5c78d520cbb172e88a50025baa155df81491b0216ced495R1) for `arguments.trailingCommas`.
4. Modify some tests
    1. [Remove this test](https://github.com/dprint/dprint-plugin-typescript/pull/489/files#diff-5de22b95cd8acf42b880d5680a2f3d0263cc3698cc456f621080d37fb3b51c03L2) which expects neither hanging nor multi-line mode for a lambda.
    2. [Correct the behaviour for tests](https://github.com/dprint/dprint-plugin-typescript/pull/489/files#diff-beec0f64c00cfe024f86987728bd6491ac6bd6e519d8aa26f21407c0c29d6f26L16) which implicitly expect neither hanging nor multi-line mode for a lambda.