### PR TITLE
Add `memberExpression.linePerExpression: methods`

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -359,13 +359,16 @@
     },
     "memberExpression.linePerExpression": {
       "description": "Whether to force a line per expression when spanning multiple lines.",
-      "type": "boolean",
-      "default": false,
+      "type": "string",
+      "default": "none",
       "oneOf": [{
-        "const": true,
+        "const": "always",
         "description": "Formats with each part on a new line."
       }, {
-        "const": false,
+        "const": "methods",
+        "description": "Formats with each successive (i.e. second onwards) method call on a new line."
+      }, {
+        "const": "none",
         "description": "Maintains the line breaks as written by the programmer."
       }]
     },

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -494,8 +494,8 @@ impl ConfigurationBuilder {
   ///
   /// * `true` - Formats with each part on a new line.
   /// * `false` (default) - Maintains the line breaks as written by the programmer.
-  pub fn member_expression_line_per_expression(&mut self, value: bool) -> &mut Self {
-    self.insert("memberExpression.linePerExpression", value.into())
+  pub fn member_expression_line_per_expression(&mut self, value: MemberExprLinePerExpression) -> &mut Self {
+    self.insert("memberExpression.linePerExpression", value.to_string().into())
   }
 
   /// The kind of separator to use in type literals.
@@ -1088,7 +1088,7 @@ mod tests {
       .arrow_function_use_parentheses(UseParentheses::Maintain)
       .binary_expression_line_per_expression(false)
       .conditional_expression_line_per_expression(true)
-      .member_expression_line_per_expression(false)
+      .member_expression_line_per_expression(MemberExprLinePerExpression::None)
       .type_literal_separator_kind(SemiColonOrComma::Comma)
       .type_literal_separator_kind_single_line(SemiColonOrComma::Comma)
       .type_literal_separator_kind_multi_line(SemiColonOrComma::Comma)
@@ -1261,6 +1261,7 @@ mod tests {
     let inner_config = config.get_inner_config();
     assert_eq!(inner_config.len(), 177);
     let diagnostics = resolve_config(inner_config, &resolve_global_config(ConfigKeyMap::new(), &Default::default()).config).diagnostics;
+    println!("{:?}", diagnostics);
     assert_eq!(diagnostics.len(), 0);
   }
 }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -101,7 +101,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     jsx_force_new_lines_surrounding_content: get_value(&mut config, "jsx.forceNewLinesSurroundingContent", false, &mut diagnostics),
     jsx_opening_element_bracket_position: get_value(&mut config, "jsxOpeningElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
     jsx_self_closing_element_bracket_position: get_value(&mut config, "jsxSelfClosingElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
-    member_expression_line_per_expression: get_value(&mut config, "memberExpression.linePerExpression", false, &mut diagnostics),
+    member_expression_line_per_expression: get_value(&mut config, "memberExpression.linePerExpression", MemberExprLinePerExpression::None, &mut diagnostics),
     type_literal_separator_kind_single_line: get_value(
       &mut config,
       "typeLiteral.separatorKind.singleLine",

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -17,6 +17,19 @@ pub enum PreferHanging {
 
 generate_str_to_from![PreferHanging, [Never, "never"], [OnlySingleItem, "onlySingleItem"], [Always, "always"]];
 
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MemberExprLinePerExpression {
+  /// Maintains the line breaks as written by the programmer.
+  None,
+  /// Maintains line breaks as written by the programmer, but forces a new line for method calls.
+  Methods,
+  /// Formats with each part on a new line.
+  All,
+}
+
+generate_str_to_from![MemberExprLinePerExpression, [None, "none"], [Methods, "methods"], [All, "all"]];
+
 /// Semi colon possibilities.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -308,7 +321,7 @@ pub struct Configuration {
   #[serde(rename = "jsxSelfClosingElement.bracketPosition")]
   pub jsx_self_closing_element_bracket_position: SameOrNextLinePosition,
   #[serde(rename = "memberExpression.linePerExpression")]
-  pub member_expression_line_per_expression: bool,
+  pub member_expression_line_per_expression: MemberExprLinePerExpression,
   #[serde(rename = "typeLiteral.separatorKind.singleLine")]
   pub type_literal_separator_kind_single_line: SemiColonOrComma,
   #[serde(rename = "typeLiteral.separatorKind.multiLine")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7862,7 +7862,7 @@ fn gen_for_flattened_member_like_expr<'a>(node: FlattenedMemberLikeExpr<'a>, con
     if item.is_optional() || !item.is_computed() {
       if force_use_new_line {
         items.push_signal(Signal::NewLine);
-      } else if !context.config.member_expression_line_per_expression {
+      } else if context.config.member_expression_line_per_expression == MemberExprLinePerExpression::None {
         items.push_condition(conditions::if_above_width(context.config.indent_width, Signal::PossibleNewLine.into()));
       } else {
         items.push_condition(if_true_or(

--- a/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_Methods_PreferSingleLine_True.txt
+++ b/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_Methods_PreferSingleLine_True.txt
@@ -1,0 +1,92 @@
+~~ lineWidth: 40, memberExpression.linePerExpression: methods, preferSingleLine: true ~~
+== should retain non-methods expressions on the same line when exceeding the width ==
+testing.this.out.for.when.it.passes.the.lineWidth.someMore;
+
+[expect]
+testing.this.out.for.when.it.passes.the
+    .lineWidth.someMore;
+
+== should break method expressions onto new lines when exceeding the width ==
+testing.this.out.for.when().it.passes.the.lineWidth().a.b;
+
+variableA.variableB.methodCallA().map(x => x.y.z).a.b.c.map((a, c) => foo).build();
+
+[expect]
+testing.this.out.for
+    .when()
+    .it.passes.the.lineWidth().a.b;
+
+variableA.variableB
+    .methodCallA()
+    .map(x => x.y.z)
+    .a.b.c.map((a, c) => foo)
+    .build();
+
+== should not break the first call expression onto a new line if it can fit on the first line ==
+a.methodCallA().map(x => x.y.z).a.b.c.map((a, c) => foo).build();
+Object.values(a).map((x, y) => {
+    const a = b + c;
+});
+
+[expect]
+a.methodCallA()
+    .map(x => x.y.z)
+    .a.b.c.map((a, c) => foo)
+    .build();
+Object.values(a).map((x, y) => {
+    const a = b + c;
+});
+
+== should not insert newlines if there is only one call expression that spans multiple lines ==
+const d = searchParams.filter(e => {
+    const a = b + c;
+});
+const d = searchParams.filter(e => {
+    const a = b + c;
+}).map(x => x);
+
+[expect]
+const d = searchParams.filter(e => {
+    const a = b + c;
+});
+const d = searchParams
+    .filter(e => {
+        const a = b + c;
+    })
+    .map(x => x);
+
+== should not consider the very first node as part of the method chain, even if it is a call expression ==
+const a = fetch(someUrl).then(r => {
+    const a = b + c;
+});
+
+[expect]
+const a = fetch(someUrl).then(r => {
+    const a = b + c;
+});
+
+== should maintain single line when below the width ==
+testing.this.out;
+
+[expect]
+testing.this.out;
+
+== should maintain single line when below the width, with methods ==
+this.someMethod().call().test();
+
+[expect]
+this.someMethod().call().test();
+
+== should be single line when below the width even when on multiple lines ==
+testing
+    .this.out;
+testing.this
+    .out;
+testing.this()
+    .out()
+    .test();
+
+[expect]
+testing.this.out;
+testing.this.out;
+testing.this().out().test();

--- a/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_True.txt
+++ b/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_True.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, memberExpression.linePerExpression: true ~~
+~~ lineWidth: 40, memberExpression.linePerExpression: all ~~
 == should go full multi-line when exceeding the width ==
 testing.this.out.for.when.it.passes.thelineWidth.someMore;
 

--- a/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_True_PreferSingleLine_True.txt
+++ b/tests/specs/expressions/MemberExpression/MemberExpression_LinePerExpression_True_PreferSingleLine_True.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, memberExpression.linePerExpression: true, preferSingleLine: true ~~
+~~ lineWidth: 40, memberExpression.linePerExpression: all, preferSingleLine: true ~~
 == should go full multi-line when exceeding the width ==
 testing.this.out.for.when.it.passes.thelineWidth.someMore;
 


### PR DESCRIPTION
# Problem

Currently, `memberExpression.preferSingleLine: true | false` and `memberExpression.linePerExpression: true | false` makes it difficult to imitate [Prettier's nice and concise behaviour](https://prettier.io/playground/#N4Igxg9gdgLgprEAuE8DOMCWUDmA6GAC0zTwgFcY8AzCAJwB0oACV5vAd0IQAoBKJm3aYqABwCGaNHFJE4eADbY4AdUwATIvzzi8AIwDcIADQgIorNDTJQ4unQgcACnYTWU4hR3EBPa6b06cTAAazgYAGVxAFs4ABllZGpPaQCg0PCIiTBsHGQYOnI4UzhovTh1dQq48VxycRw4ADF6aPEYLFxkEHFKCBMQQhhohRVidGy4CLcRTAA3ER9usCkB7Gk6GCcgnDaklOKQACs0AA8I3IU4AEVyCHh9hVSQCToN7r1xcoUB0QdpFRBUTdP4yOB0OZwAYARzu8G25ncPTQAFooHAKhUBnQ4LDMDjtg09khkk9DtJoph8oVyZc4ABBDp0TB6ShwJzghLox7PNB0273KEkg6mGBfNSaQjIABMoqCmCUuAAwhBosSQDIAKwDcjSAAqX3cpOecyKAEkoFVYBEwMyLPTLREYD4rjzDn9sDAJURkAAWAAMAF9A0A) of "line break only after successive methods in chained member expressions".

# Changes

Change `memberExpression:linePerExpression` to accept `all | methods | none` instead of `true | false` to enable the following behaviour. 

```
~~ lineWidth: 40, memberExpression.linePerExpression: methods, preferSingleLine: true ~~
== should break method expressions onto new lines when exceeding the width ==
testing.this.out.for.when().it.passes.the.lineWidth().a.b;

variableA.variableB.methodCallA().map(x => x.y.z).a.b.c.reduce((a, c) => foo, {}).build();

[expect]
testing.this.out.for
    .when()
    .it.passes.the.lineWidth().a.b;

variableA.variableB
    .methodCallA()
    .map(x => x.y.z)
    .a.b.c.reduce((a, c) => foo, {})
    .build();
```