### PR TITLE
union types: fix trailing comment causing multiline when preferSingleLine is true

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -9292,37 +9292,40 @@ fn has_any_node_comment_on_different_line(nodes: &[impl SourceRanged], context: 
 
     let node_end = node.end();
     let next_node_pos = nodes.get(i + 1).map(|n| n.start());
-    if check_pos_has_trailing_comments(node_end, next_node_pos, context) {
+    let comment_kind = if let Some(comma) = context.token_finder.get_next_token_if_comma(&node_end) {
+      get_pos_trailing_comments(comma.end(), next_node_pos, context)
+    } else {
+      get_pos_trailing_comments(node_end, next_node_pos, context)
+    };
+
+    // the final node is allowed to have a trailing line comment as it'll be on the same line
+    if comment_kind.is_some() && !(i == nodes.len() - 1 && comment_kind == Some(CommentKind::Line)){
       return true;
-    } else if let Some(comma) = context.token_finder.get_next_token_if_comma(&node_end) {
-      if check_pos_has_trailing_comments(comma.end(), next_node_pos, context) {
-        return true;
-      }
     }
   }
 
   return false;
 
-  fn check_pos_has_trailing_comments(end: SourcePos, next_node_pos: Option<SourcePos>, context: &mut Context) -> bool {
+  fn get_pos_trailing_comments(end: SourcePos, next_node_pos: Option<SourcePos>, context: &mut Context) -> Option<CommentKind> {
     let end_line = end.end_line_fast(context.program);
     let stop_line = next_node_pos.map(|p| p.start_line_fast(context.program));
 
     for c in end.trailing_comments_fast(context.program) {
       if c.kind == CommentKind::Line {
-        return true;
+        return Some(CommentKind::Line);
       }
       if let Some(stop_line) = stop_line {
         if c.start_line_fast(context.program) >= stop_line {
           // do not look at comments that the next node owns
-          return false;
+          return None;
         }
       }
       if c.end_line_fast(context.program) > end_line {
-        return true;
+        return Some(CommentKind::Block);
       }
     }
 
-    false
+    None
   }
 }
 

--- a/tests/specs/types/UnionType/UnionType_PreferSingleLine_True.txt
+++ b/tests/specs/types/UnionType/UnionType_PreferSingleLine_True.txt
@@ -20,3 +20,31 @@ export type T =
 
 [expect]
 export type T = string | test | other;
+
+== should be multi line when over the line width ==
+export type T = string | test | other1 | other2 | other3;
+
+[expect]
+export type T =
+    | string
+    | test
+    | other1
+    | other2
+    | other3;
+
+== should be single line if the final type has a trailing comment (only) ==
+export type T = string|number // TODO
+
+[expect]
+export type T = string | number; // TODO
+
+== should be multi line if any type apart from the final type has a trailing comment ==
+export type T = string|number // TODO
+  | foo | bar
+
+[expect]
+export type T =
+    | string
+    | number // TODO
+    | foo
+    | bar;


### PR DESCRIPTION
`has_any_node_comment_on_different_line` doesn't currently consider the case where the final node has a trailing line comment (which is therefore on the same line). 

This causes issues such as the following, where we see union types randomly get multi-lined when we add a trailing comment:

Input:
```ts
function f(
    arg: '1' | '2',
    otherArg: string,
) { }
```

add a `// todo: fix me` after `arg: '1' | '2',`

Output:
```ts
function f(
  arg:
    | '1'
    | '2', // todo: fix me
  otherArg: string,
) { }
```

Expected:
```ts
function f(
    arg: '1' | '2', // todo: fix me
    otherArg: string,
) { }
```

This PR fixes that by allowing a trailing line comment for the last node in the node list. 