### PR TITLE
fix: keep braces on if & while statements when block body contains single decl

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -8435,7 +8435,9 @@ fn gen_conditional_brace_body<'a>(opts: GenConditionalBraceBodyOptions<'a>, cont
 
   fn get_force_braces(body_node: Node) -> bool {
     if let Node::BlockStmt(body_node) = body_node {
-      body_node.stmts.is_empty() || body_node.stmts.iter().all(|s| s.kind() == NodeKind::EmptyStmt)
+      body_node.stmts.is_empty()
+        || body_node.stmts.iter().all(|s| s.kind() == NodeKind::EmptyStmt)
+        || (body_node.stmts.len() == 1 && matches!(body_node.stmts[0], Stmt::Decl(_)))
     } else {
       false
     }

--- a/tests/specs/issues/issue0510.txt
+++ b/tests/specs/issues/issue0510.txt
@@ -1,0 +1,11 @@
+== should not remove braces in an if/while statement when the body contains a declaration ==
+if (true) { const _err = 5; }
+while (true) { const _err = 5; }
+if (true) { class Test {} }
+while (true) { class Test {} }
+
+[expect]
+if (true) { const _err = 5; }
+while (true) { const _err = 5; }
+if (true) { class Test {} }
+while (true) { class Test {} }


### PR DESCRIPTION
Closes #510