### PR TITLE
fix(asi): do not put semi-colon at start of expression stmt body in do while stmt

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -4543,7 +4543,7 @@ fn gen_namespace_export<'a>(node: &TsNamespaceExportDecl<'a>, context: &mut Cont
 }
 
 fn gen_expr_stmt<'a>(stmt: &ExprStmt<'a>, context: &mut Context<'a>) -> PrintItems {
-  if context.config.semi_colons.is_true() {
+  if context.config.semi_colons.is_true() || stmt.parent().is::<DoWhileStmt>() {
     return gen_inner(stmt, context);
   } else {
     return gen_for_prefix_semi_colon_insertion(stmt, context);

--- a/tests/specs/issues/deno/issue020089.txt
+++ b/tests/specs/issues/deno/issue020089.txt
@@ -1,0 +1,7 @@
+~~ semiColons: asi ~~
+== should not add semi-colon at start ==
+do ++x; while (x<10)
+
+[expect]
+do ++x
+while (x < 10)


### PR DESCRIPTION
For https://github.com/denoland/deno/issues/20089