### PR TITLE
fix: quote props consistent

### DIFF
--- a/src/generation/context.rs
+++ b/src/generation/context.rs
@@ -173,12 +173,12 @@ impl<'a> Context<'a> {
   ) -> TReturn {
     if self.config.quote_props == QuoteProps::Consistent {
       self.consistent_quote_props_stack.push((use_consistent_quotes)(&state));
-    }
-    let result = action(self, state);
-    if self.config.quote_props == QuoteProps::Consistent {
+      let result = action(self, state);
       self.consistent_quote_props_stack.pop();
+      result
+    } else {
+      action(self, state)
     }
-    result
   }
 
   // do any assertions for how the state of this context should be at the end of the file

--- a/src/generation/context.rs
+++ b/src/generation/context.rs
@@ -174,10 +174,10 @@ impl<'a> Context<'a> {
     if self.config.quote_props == QuoteProps::Consistent {
       self.consistent_quote_props_stack.push((use_consistent_quotes)(&state));
     }
-    let is_consistent = self.consistent_quote_props_stack.peek().copied().unwrap_or(true);
-    self.consistent_quote_props_stack.push(is_consistent);
     let result = action(self, state);
-    self.consistent_quote_props_stack.pop();
+    if self.config.quote_props == QuoteProps::Consistent {
+      self.consistent_quote_props_stack.pop();
+    }
     result
   }
 

--- a/tests/specs/literals/StringLiteral/StringLiteral_QuoteProps_Consistent.txt
+++ b/tests/specs/literals/StringLiteral/StringLiteral_QuoteProps_Consistent.txt
@@ -158,3 +158,19 @@ type Type = {
     set foo3(v: string);
     foo4: "literal";
 };
+
+== should not remove in this scenario ==
+const x = {
+    "/src/shared/tsconfig-base.json": JSON.stringify({
+        include: ["./typings-base/"],
+    }),
+    "/src/shared/index.ts": `export const a: Unrestricted = 1;`,
+}
+
+[expect]
+const x = {
+    "/src/shared/tsconfig-base.json": JSON.stringify({
+        include: ["./typings-base/"],
+    }),
+    "/src/shared/index.ts": `export const a: Unrestricted = 1;`,
+};


### PR DESCRIPTION
Caused by mindlessly accepting a copilot suggestion. You can see the correct code becoming incorrect in this commit:

https://github.com/dprint/dprint-plugin-typescript/pull/544/commits/3df111e5a8bafdd9a45d1818d51ebf263a64a6d5