### PR TITLE
feat: support import attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c93119b1c487a85603406a988a0ca9a1d0e5315404cccc5c158fb484b1f5a2"
+checksum = "b041461b8b531a409fc635a5a476aee79b82f2c502d1d279c5995b6768ed944a"
 dependencies = [
  "deno_media_type",
  "dprint-swc-ext",
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "deno_media_type"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d69b833ed4d244b608bab9c07069bfb570f631b763b58e73f82a020bf84ef"
+checksum = "a798670c20308e5770cc0775de821424ff9e85665b602928509c8c70430b3ee0"
 dependencies = [
  "serde",
 ]
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ext"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f115ea5b6f5d0d02a25a9364f41b8c4f857452c299309dcfd29a694724d0566"
+checksum = "6a0a2492465344a58a37ae119de59e81fe5a2885f2711c7b5048ef0dfa14ce42"
 dependencies = [
  "bumpalo",
  "num-bigint",
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8066e17abb484602da673e2d35138ab32ce53f26368d9c92113510e1659220b"
+checksum = "9f54563d7dcba626d4acfe14ed12def7ecc28e004debe3ecd2c3ee07cc47e449"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.31.21"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5823ef063f116ad281cde9700f5be6dfb182e543ce3f62c42cee1c03ffbc6b"
+checksum = "39cb7fcd56655c8ae7dcf2344f0be6cbff4d9c7cb401fe3ec8e56e1de8dfe582"
 dependencies = [
  "ast_node",
  "better_scoped_tls",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.107.7"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7191c8c57af059b75a2aadc927a2608c3962d19e4d09ce8f9c3f03739ddf833"
+checksum = "7bc2286cedd688a68f214faa1c19bb5cceab7c9c54d0cbe3273e4c1704e38f69"
 dependencies = [
  "bitflags 2.4.0",
  "is-macro",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.137.15"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c0d554865a63bfa58cf1c433fa91d7d4adf40030fa8e4530e8065d0578166a"
+checksum = "3eab46cb863bc5cd61535464e07e5b74d5f792fa26a27b9f6fd4c8daca9903b7"
 dependencies = [
  "either",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing = ["dprint-core/tracing"]
 
 [dependencies]
 anyhow = "1.0.64"
-deno_ast = { version = "0.28.0", features = ["view"] }
+deno_ast = { version = "0.29.0", features = ["view"] }
 dprint-core = { version = "0.62.0", features = ["formatting"] }
 rustc-hash = "1.1.0"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1063,9 +1063,8 @@ fn gen_export_named_decl<'a>(node: &NamedExport<'a>, context: &mut Context<'a>) 
     items.extend(gen_node(src.into(), context));
   }
 
-  if let Some(asserts) = node.asserts {
-    items.push_str(" assert ");
-    items.extend(gen_node(asserts.into(), context));
+  if let Some(with_clause) = node.with {
+    items.extend(gen_with_clause(with_clause, context));
   }
 
   if context.config.semi_colons.is_true() {
@@ -1261,9 +1260,8 @@ fn gen_import_decl<'a>(node: &ImportDecl<'a>, context: &mut Context<'a>) -> Prin
 
   items.extend(gen_node(node.src.into(), context));
 
-  if let Some(asserts) = node.asserts {
-    items.push_str(" assert ");
-    items.extend(gen_node(asserts.into(), context));
+  if let Some(with_clause) = node.with {
+    items.extend(gen_with_clause(with_clause, context));
   }
 
   if context.config.semi_colons.is_true() {
@@ -4505,15 +4503,22 @@ fn gen_export_all<'a>(node: &ExportAll<'a>, context: &mut Context<'a>) -> PrintI
   }
   items.extend(gen_node(node.src.into(), context));
 
-  if let Some(asserts) = node.asserts {
-    items.push_str(" assert ");
-    items.extend(gen_node(asserts.into(), context));
+  if let Some(with_clause) = node.with {
+    items.extend(gen_with_clause(with_clause, context));
   }
 
   if context.config.semi_colons.is_true() {
     items.push_str(";");
   }
 
+  items
+}
+
+fn gen_with_clause<'a>(node: &ObjectLit<'a>, context: &mut Context<'a>) -> PrintItems {
+  let mut items = PrintItems::new();
+  let previous_token_text = node.previous_token_fast(context.program).text_fast(context.program);
+  items.push_str(if previous_token_text == "assert" { " assert " } else { " with " });
+  items.extend(gen_node(node.into(), context));
   items
 }
 

--- a/tests/specs/declarations/export/ExportAllDeclaration_All.txt
+++ b/tests/specs/declarations/export/ExportAllDeclaration_All.txt
@@ -16,3 +16,13 @@ export * from "a" assert { type: "json" };
 export * from "testingtesttest" assert {
     type: "json",
 };
+
+== should format attributes ==
+export * from "a" with {type: "json"};
+export * from "testingtesttest" with { type: "json" };
+
+[expect]
+export * from "a" with { type: "json" };
+export * from "testingtesttest" with {
+    type: "json",
+};

--- a/tests/specs/declarations/export/ExportNamedDeclaration_All.txt
+++ b/tests/specs/declarations/export/ExportNamedDeclaration_All.txt
@@ -162,3 +162,18 @@ export {
     n3,
     n4,
 } from "test" assert { type: "json" };
+
+== should format attributes ==
+export { } from "a" with {a: "a"};
+export { asdf } from "test" with { type: "json" };
+export { n1, n2, n3, n4 } from "test" with { type: "json" };
+
+[expect]
+export {} from "a" with { a: "a" };
+export { asdf } from "test" with { type: "json" };
+export {
+    n1,
+    n2,
+    n3,
+    n4,
+} from "test" with { type: "json" };

--- a/tests/specs/declarations/import/ImportDeclaration_All.txt
+++ b/tests/specs/declarations/import/ImportDeclaration_All.txt
@@ -156,3 +156,13 @@ import test from "a" assert { type: "json" };
 import asdf from "testing.json" assert {
     type: "json",
 };
+
+== should support import attributes ==
+import test from "a" with {type: "json"};
+import asdf from "testing.json" with {type:"json"};
+
+[expect]
+import test from "a" with { type: "json" };
+import asdf from "testing.json" with {
+    type: "json",
+};


### PR DESCRIPTION
This adds support for import attributes, while maintaining import assertions for now.

In the future, this will probably automatically convert import assertions to import attributes.