### PR TITLE
fix(regression): call expr with/without optional chain should not format differently in tpl lit

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3017,6 +3017,7 @@ fn gen_template_literal<'a>(quasis: Vec<Node<'a>>, exprs: Vec<Node<'a>>, context
 
   fn get_possible_surround_newlines(node: Node) -> bool {
     match node {
+      Node::OptChainExpr(expr) => get_possible_surround_newlines(expr.base.as_node()),
       Node::CondExpr(_) => true,
       Node::BinExpr(_) => true,
       Node::MemberExpr(expr) => !keep_member_expr_on_one_line(expr),

--- a/tests/specs/issues/issue0556.txt
+++ b/tests/specs/issues/issue0556.txt
@@ -1,0 +1,40 @@
+~~ lineWidth: 1000, indentWidth: 4, operatorPosition: sameLine ~~
+== should maintain ==
+// these should both format the same, regardless of whether there is an
+// optional chain or not at symbol.declarations?.map
+function getSymbolParentOrFail() {
+    return `Declarations: ${
+        symbol.declarations?.map(d => {
+            return true;
+        }).join(", ")
+    }.`;
+}
+
+[expect]
+// these should both format the same, regardless of whether there is an
+// optional chain or not at symbol.declarations?.map
+function getSymbolParentOrFail() {
+    return `Declarations: ${
+        symbol.declarations?.map(d => {
+            return true;
+        }).join(", ")
+    }.`;
+}
+
+== should format this the same as the above ==
+function getSymbolParentOrFail() {
+    return `Declarations: ${
+        symbol.declarations.map(d => {
+            return true;
+        }).join(", ")
+    }.`;
+}
+
+[expect]
+function getSymbolParentOrFail() {
+    return `Declarations: ${
+        symbol.declarations.map(d => {
+            return true;
+        }).join(", ")
+    }.`;
+}

--- a/tests/specs/issues/issue0556.txt
+++ b/tests/specs/issues/issue0556.txt
@@ -1,5 +1,5 @@
 ~~ lineWidth: 1000, indentWidth: 4, operatorPosition: sameLine ~~
-== should maintain ==
+== should format same as the below ==
 // these should both format the same, regardless of whether there is an
 // optional chain or not at symbol.declarations?.map
 function getSymbolParentOrFail() {


### PR DESCRIPTION
Closes #556