### PR TITLE
feat: add parens around unary expressions in in/instanceof

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3052,6 +3052,11 @@ fn gen_unary_expr<'a>(node: &UnaryExpr<'a>, context: &mut Context<'a>) -> PrintI
   let mut items = PrintItems::new();
   items.push_str(get_operator_text(node.op()));
   items.extend(gen_node(node.arg.into(), context));
+
+  if get_should_use_parens(node) {
+    items = surround_with_parens(items);
+  }
+
   return items;
 
   fn get_operator_text<'a>(op: UnaryOp) -> &'a str {
@@ -3064,6 +3069,13 @@ fn gen_unary_expr<'a>(node: &UnaryExpr<'a>, context: &mut Context<'a>) -> PrintI
       UnaryOp::Minus => "-",
       UnaryOp::Tilde => "~",
     }
+  }
+
+  fn get_should_use_parens(node: &UnaryExpr) -> bool {
+    if let Node::BinExpr(parent) = node.parent() {
+      return matches!(parent.op(), BinaryOp::In | BinaryOp::InstanceOf);
+    }
+    false
   }
 }
 

--- a/tests/specs/expressions/BinaryExpression/BinaryExpression_Unary_In.txt
+++ b/tests/specs/expressions/BinaryExpression/BinaryExpression_Unary_In.txt
@@ -1,0 +1,39 @@
+== should properly parenthesize ! operator in in ==
+!foo in bar;
+(!foo in bar);
+!(foo in bar);
+(!foo) in bar;
+!!foo in bar;
+
+[expect]
+(!foo) in bar;
+(!foo) in bar;
+!(foo in bar);
+(!foo) in bar;
+(!!foo) in bar;
+
+== should properly parenthesize ! operator in instanceof ==
+!foo instanceof Bar;
+(!foo instanceof Bar);
+!(foo instanceof Bar);
+(!foo) instanceof Bar;
+!!foo instanceof bar;
+
+[expect]
+(!foo) instanceof Bar;
+(!foo) instanceof Bar;
+!(foo instanceof Bar);
+(!foo) instanceof Bar;
+(!!foo) instanceof bar;
+
+== should properly parenthesize void operator in instanceof ==
+void 0 in bar;
+(void 0 in bar);
+void (0 in bar);
+(void 0) in bar;
+
+[expect]
+(void 0) in bar;
+(void 0) in bar;
+void (0 in bar);
+(void 0) in bar;


### PR DESCRIPTION
At a [TC39 meeting this week](https://github.com/tc39/agendas/blob/main/2023/09.md) we are discuss about a proposal for `!in` and `!instanceof`, to allow writing `x !in y` rather than `!(x in y)`. One of the main motivator factors is that it's very common ([see the slides that will be presented](https://docs.google.com/presentation/d/1vwNOjUiUvy6TzK6t0Mb8qgyKwBNszly9HibJJpUa_Eo/edit#slide=id.g27f462e9ca3_0_0)) to forget parentheses around `(x in y)` when writing `!(x in y)`.

Given the easy confusion, formatters could add parenthesis to make meaning of the code clear. If my code is automatically formatted to `(!x) in y`, if would not assume that it's doing `!(x in y)`. (**NOTE** This is my idea, not TC39's position -- we didn't actually talk about that proposal yet :) ) How do you feel about this?

This PR will also format `x in !y` to `x in (!y)`. This doesn't help with avoiding any ambiguity, but given that that code always results in a runtime error I assume that nobody will actually write it and so it doesn't really matter how it gets formatted. This lets us avoid checking if the unary expression is on the left or right of `in`.

Prettier parallel issue: https://github.com/prettier/prettier/issues/15434

Note that prettier _already_ adds parentheses for `await x instanceof y`. I didn't add it to this PR because prettier's `await` behavior is that it always adds parens when `await` is used in any binary expression, while dprint does not.