### PR TITLE
fix: maintain parens for jsx element in member expr

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3648,8 +3648,11 @@ fn is_jsx_paren_expr_handled_node<'a>(node: Node<'a>, context: &Context<'a>) -> 
     return true;
   }
 
-  // do not allow in expr statement, argument, attributes, or jsx exprs
-  !matches!(parent.kind(), NodeKind::ExprStmt | NodeKind::ExprOrSpread | NodeKind::JSXExprContainer)
+  // do not allow in expr statement, argument, attributes, jsx exprs, or member exprs
+  !matches!(
+    parent.kind(),
+    NodeKind::ExprStmt | NodeKind::ExprOrSpread | NodeKind::JSXExprContainer | NodeKind::MemberExpr
+  )
 }
 
 fn gen_jsx_element<'a>(node: &JSXElement<'a>, context: &mut Context<'a>) -> PrintItems {

--- a/tests/specs/issues/deno/issue021279.txt
+++ b/tests/specs/issues/deno/issue021279.txt
@@ -1,0 +1,7 @@
+== should not cause syntax error ==
+const $$children = (<>{children}</>).toString();
+const { getLayer } = await uno.generate($$children, { minify: true })
+
+[expect]
+const $$children = (<>{children}</>).toString();
+const { getLayer } = await uno.generate($$children, { minify: true });


### PR DESCRIPTION
For https://github.com/denoland/deno/issues/21279