### PR TITLE
fix: `arguments.spaceAround` not adding spaces when an arrow function is the only argument

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7273,7 +7273,7 @@ where
             Some(is_different_line && is_different_start_line_indentation)
           }),
           Signal::NewLine.into(),
-          if space_around { Signal::SpaceIfNotTrailing.into() } else { "".into() },
+          if space_around { Signal::SpaceIfNotTrailing.into() } else { PrintItems::new() },
         ));
       } else {
         let last_comma_token = nodes.last().and_then(|n| context.token_finder.get_next_token_if_comma(n));

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7263,7 +7263,7 @@ where
           items.push_signal(Signal::SpaceIfNotTrailing);
         }
         items.push_condition(conditions::indent_if_start_of_line(generated_node));
-        items.push_condition(if_true(
+        items.push_condition(if_true_or(
           "isDifferentLineAndStartLineIndentation",
           Rc::new(move |context| {
             let start_ln = context.resolved_line_number(start_ln)?;
@@ -7273,10 +7273,8 @@ where
             Some(is_different_line && is_different_start_line_indentation)
           }),
           Signal::NewLine.into(),
+          if space_around { Signal::SpaceIfNotTrailing.into() } else { "".into() },
         ));
-        if space_around {
-          items.push_signal(Signal::SpaceIfNotTrailing);
-        }
       } else {
         let last_comma_token = nodes.last().and_then(|n| context.token_finder.get_next_token_if_comma(n));
         items.extend(gen_separated_values(

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7259,6 +7259,9 @@ where
         items.push_info(start_ln);
         items.push_info(start_lsil);
         items.push_signal(Signal::PossibleNewLine);
+        if space_around {
+          items.push_signal(Signal::SpaceIfNotTrailing);
+        }
         items.push_condition(conditions::indent_if_start_of_line(generated_node));
         items.push_condition(if_true(
           "isDifferentLineAndStartLineIndentation",
@@ -7271,6 +7274,9 @@ where
           }),
           Signal::NewLine.into(),
         ));
+        if space_around {
+          items.push_signal(Signal::SpaceIfNotTrailing);
+        }
       } else {
         let last_comma_token = nodes.last().and_then(|n| context.token_finder.get_next_token_if_comma(n));
         items.extend(gen_separated_values(

--- a/tests/specs/general/Arguments_SpaceAround_True.txt
+++ b/tests/specs/general/Arguments_SpaceAround_True.txt
@@ -35,3 +35,17 @@ testing() === true;
 [expect]
 testing();
 testing() === true;
+
+== should not add spaces when indented ==
+function test() {
+    then( () =>
+        abcdefghijklmnop()
+     );
+}
+
+[expect]
+function test() {
+    then( () =>
+        abcdefghijklmnop()
+    );
+}

--- a/tests/specs/general/Arguments_SpaceAround_True.txt
+++ b/tests/specs/general/Arguments_SpaceAround_True.txt
@@ -5,6 +5,8 @@ testing(1, 2, 3);
 testing({a: 5});
 testing({abcdefghijklmnop: true, bcdefg: false});
 testing(123456, 123456, 123456, 123456);
+then(() => ({abcdefghijklmnop: true, bcdefg: false}));
+then(() => done());
 
 [expect]
 testing( true );
@@ -20,6 +22,11 @@ testing(
     123456,
     123456,
 );
+then( () => ({
+    abcdefghijklmnop: true,
+    bcdefg: false,
+}) );
+then( () => done() );
 
 == should not add spaces on empty arguments ==
 testing()


### PR DESCRIPTION
Fixes #581

The `if !force_use_new_lines && nodes.len() == 1 && is_arrow_function_with_expr_body(nodes[0])` path wasn't considering the `space_around` option. I'm not sure if this is the most correct way to fix this problem, but it at least works on my codebase and passes the tests.