### PR TITLE
feat: add catchClause.spaceAround

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -895,6 +895,9 @@
     "whileStatement.spaceAround": {
       "$ref": "#/definitions/spaceAround"
     },
+    "catchStatement.spaceAround": {
+      "$ref": "#/definitions/spaceAround"
+    },
     "spaceSurroundingProperties": {
       "$ref": "#/definitions/spaceSurroundingProperties"
     },

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -868,6 +868,9 @@
     "arrayPattern.spaceAround": {
       "$ref": "#/definitions/spaceAround"
     },
+    "catchClause.spaceAround": {
+      "$ref": "#/definitions/spaceAround"
+    },
     "doWhileStatement.spaceAround": {
       "$ref": "#/definitions/spaceAround"
     },
@@ -893,9 +896,6 @@
       "$ref": "#/definitions/spaceAround"
     },
     "whileStatement.spaceAround": {
-      "$ref": "#/definitions/spaceAround"
-    },
-    "catchStatement.spaceAround": {
       "$ref": "#/definitions/spaceAround"
     },
     "spaceSurroundingProperties": {

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -1269,7 +1269,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 178);
+    assert_eq!(inner_config.len(), 179);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -1008,6 +1008,10 @@ impl ConfigurationBuilder {
     self.insert("arrayPattern.spaceAround", value.into())
   }
 
+  pub fn catch_clause_space_around(&mut self, value: bool) -> &mut Self {
+    self.insert("catchClause.spaceAround", value.into())
+  }
+
   pub fn do_while_statement_space_around(&mut self, value: bool) -> &mut Self {
     self.insert("doWhileStatement.spaceAround", value.into())
   }
@@ -1248,6 +1252,7 @@ mod tests {
       .arguments_space_around(true)
       .array_expression_space_around(true)
       .array_pattern_space_around(true)
+      .catch_clause_space_around(true)
       .do_while_statement_space_around(true)
       .for_in_statement_space_around(true)
       .for_of_statement_space_around(true)
@@ -1259,7 +1264,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 177);
+    assert_eq!(inner_config.len(), 178);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -318,6 +318,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     switch_statement_space_around: get_value(&mut config, "switchStatement.spaceAround", space_around, &mut diagnostics),
     tuple_type_space_around: get_value(&mut config, "tupleType.spaceAround", space_around, &mut diagnostics),
     while_statement_space_around: get_value(&mut config, "whileStatement.spaceAround", space_around, &mut diagnostics),
+    catch_clause_space_around: get_value(&mut config, "catchClause.spaceAround", space_around, &mut diagnostics),
   };
 
   diagnostics.extend(get_unknown_property_diagnostics(config));

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -309,6 +309,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     arguments_space_around: get_value(&mut config, "arguments.spaceAround", space_around, &mut diagnostics),
     array_expression_space_around: get_value(&mut config, "arrayExpression.spaceAround", space_around, &mut diagnostics),
     array_pattern_space_around: get_value(&mut config, "arrayPattern.spaceAround", space_around, &mut diagnostics),
+    catch_clause_space_around: get_value(&mut config, "catchClause.spaceAround", space_around, &mut diagnostics),
     do_while_statement_space_around: get_value(&mut config, "doWhileStatement.spaceAround", space_around, &mut diagnostics),
     for_in_statement_space_around: get_value(&mut config, "forInStatement.spaceAround", space_around, &mut diagnostics),
     for_of_statement_space_around: get_value(&mut config, "forOfStatement.spaceAround", space_around, &mut diagnostics),
@@ -318,7 +319,6 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     switch_statement_space_around: get_value(&mut config, "switchStatement.spaceAround", space_around, &mut diagnostics),
     tuple_type_space_around: get_value(&mut config, "tupleType.spaceAround", space_around, &mut diagnostics),
     while_statement_space_around: get_value(&mut config, "whileStatement.spaceAround", space_around, &mut diagnostics),
-    catch_clause_space_around: get_value(&mut config, "catchClause.spaceAround", space_around, &mut diagnostics),
   };
 
   diagnostics.extend(get_unknown_property_diagnostics(config));

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -628,4 +628,6 @@ pub struct Configuration {
   pub tuple_type_space_around: bool,
   #[serde(rename = "whileStatement.spaceAround")]
   pub while_statement_space_around: bool,
+  #[serde(rename = "catchClause.spaceAround")]
+  pub catch_clause_space_around: bool,
 }

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -610,6 +610,8 @@ pub struct Configuration {
   pub array_expression_space_around: bool,
   #[serde(rename = "arrayPattern.spaceAround")]
   pub array_pattern_space_around: bool,
+  #[serde(rename = "catchClause.spaceAround")]
+  pub catch_clause_space_around: bool,
   #[serde(rename = "doWhileStatement.spaceAround")]
   pub do_while_statement_space_around: bool,
   #[serde(rename = "forInStatement.spaceAround")]
@@ -628,6 +630,4 @@ pub struct Configuration {
   pub tuple_type_space_around: bool,
   #[serde(rename = "whileStatement.spaceAround")]
   pub while_statement_space_around: bool,
-  #[serde(rename = "catchClause.spaceAround")]
-  pub catch_clause_space_around: bool,
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -728,7 +728,13 @@ fn gen_catch_clause<'a>(node: &CatchClause<'a>, context: &mut Context<'a>) -> Pr
 
   if let Some(param) = &node.param {
     items.push_str(" (");
+    if context.config.catch_clause_space_around {
+      items.push_str(" ");
+    }
     items.extend(gen_node(param.into(), context));
+    if context.config.catch_clause_space_around {
+      items.push_str(" ");
+    }
     items.push_str(")");
   }
   items.push_info(end_header_ln);

--- a/tests/specs/clauses/catchClause/CatchClause_SpaceAround_True.txt
+++ b/tests/specs/clauses/catchClause/CatchClause_SpaceAround_True.txt
@@ -1,0 +1,42 @@
+~~ catchClause.spaceAround: true ~~
+== should output without param ==
+try{
+    a;
+} catch
+{
+    b;
+}
+
+[expect]
+try {
+    a;
+} catch {
+    b;
+}
+
+== should output with param ==
+try{
+    a;
+}
+catch(ex){
+    b;
+}
+
+[expect]
+try {
+    a;
+} catch ( ex ) {
+    b;
+}
+
+== should output with type on param ==
+try {
+    a
+} catch (  ex    :unknown ) {
+}
+
+[expect]
+try {
+    a;
+} catch ( ex: unknown ) {
+}


### PR DESCRIPTION
This adds spaces around the parameter in a catch clause. Examples:
```ts
// catchClause.spaceAround: false
try {
    a;
}
catch(ex){
    b;
}
// catchClause.spaceAround: true
try {
    a;
} catch ( ex ) {
    b;
}
```