### PR TITLE
refactor: rename `onlyWhenMultiple` to `whenMultiple`

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -293,7 +293,7 @@
         "const": "never",
         "description": ""
       }, {
-        "const": "onlyWhenMultiple",
+        "const": "whenMultiple",
         "description": "Force multiple lines only if importing more than one thing."
       }]
     },

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -66,10 +66,10 @@ pub enum ForceMultiLine {
   /// Always force multiline imports/exports.
   Always,
   /// Mulitline imports/exports should be forced only when importing/exporting multiple items.
-  OnlyWhenMultiple,
+  WhenMultiple,
 }
 
-generate_str_to_from![ForceMultiLine, [Always, "always"], [Never, "never"], [OnlyWhenMultiple, "onlyWhenMultiple"]];
+generate_str_to_from![ForceMultiLine, [Always, "always"], [Never, "never"], [WhenMultiple, "whenMultiple"]];
 
 /// Where to place the opening brace.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -1036,7 +1036,7 @@ fn gen_export_named_decl<'a>(node: &NamedExport<'a>, context: &mut Context<'a>) 
 
   let force_multi_line = !force_single_line
     && ((context.config.export_declaration_force_multi_line == ForceMultiLine::Always)
-      || (named_exports.len() > 1 && context.config.export_declaration_force_multi_line == ForceMultiLine::OnlyWhenMultiple));
+      || (named_exports.len() > 1 && context.config.export_declaration_force_multi_line == ForceMultiLine::WhenMultiple));
 
   let should_single_line = force_single_line
     || (default_export.is_none()
@@ -1226,7 +1226,7 @@ fn gen_import_decl<'a>(node: &ImportDecl<'a>, context: &mut Context<'a>) -> Prin
   let force_single_line = context.config.import_declaration_force_single_line && !contains_line_or_multiline_comment(node.into(), context.program);
 
   let force_multi_line = context.config.import_declaration_force_multi_line == ForceMultiLine::Always
-    || (named_imports.len() > 1 && context.config.import_declaration_force_multi_line == ForceMultiLine::OnlyWhenMultiple);
+    || (named_imports.len() > 1 && context.config.import_declaration_force_multi_line == ForceMultiLine::WhenMultiple);
 
   let should_single_line = force_single_line
     || (default_import.is_none()

--- a/tests/specs/declarations/export/ExportDeclaration_ForceMultiLine_OnlyWhenMultiple.txt
+++ b/tests/specs/declarations/export/ExportDeclaration_ForceMultiLine_OnlyWhenMultiple.txt
@@ -1,4 +1,4 @@
-~~ exportDeclaration.forceMultiLine: onlyWhenMultiple, lineWidth: 40 ~~
+~~ exportDeclaration.forceMultiLine: whenMultiple, lineWidth: 40 ~~
 == should never add a new line between exports ==
 export { testing, a, b, c, d, e } from "./test.ts";
 export { testing, a, b, c, d, e // test

--- a/tests/specs/declarations/import/ImportDeclaration_ForceMultiLine_OnlyWhenMultiple.txt
+++ b/tests/specs/declarations/import/ImportDeclaration_ForceMultiLine_OnlyWhenMultiple.txt
@@ -1,4 +1,4 @@
-~~ importDeclaration.forceMultiLine: onlyWhenMultiple, lineWidth: 40 ~~
+~~ importDeclaration.forceMultiLine: whenMultiple, lineWidth: 40 ~~
 == should break imports when more than one ==
 import { a, b } from "./test.ts";
 


### PR DESCRIPTION
Just thought of this. It's slightly shorter.

Follow up to #617