### PR TITLE
fix: correct spaceBeforeParentheses for `export default function` with name

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2581,7 +2581,7 @@ fn gen_fn_expr<'a>(node: &FnExpr<'a>, context: &mut Context<'a>) -> PrintItems {
   let items = gen_function_decl_or_expr(
     FunctionDeclOrExprNode {
       node: node.into(),
-      is_func_decl: false,
+      is_func_decl: node.parent().kind() == NodeKind::ExportDefaultDecl && node.ident.is_some(),
       ident: node.ident,
       declare: false,
       func: node.function,

--- a/tests/specs/declarations/function/Function_SpaceBeforeParentheses_True.txt
+++ b/tests/specs/declarations/function/Function_SpaceBeforeParentheses_True.txt
@@ -3,8 +3,14 @@
 function test<T>() {
 }
 
+export default function test() {
+}
+
 [expect]
 function test<T> () {
+}
+
+export default function test () {
 }
 
 == should format with a space before the parens even when multi-line ==

--- a/tests/specs/expressions/FunctionExpression/FunctionExpression_SpaceBeforeParentheses_True.txt
+++ b/tests/specs/expressions/FunctionExpression/FunctionExpression_SpaceBeforeParentheses_True.txt
@@ -8,6 +8,11 @@ const w = function test<T>(testing, thisOut){
 const x = function*() {};
 const y = function ident() {};
 
+export default function test() {
+}
+export default function() {
+}
+
 [expect]
 const t = function (p, u) {};
 const u = function<T> (p, u) {};
@@ -19,3 +24,8 @@ const w = function test<T> (
 };
 const x = function* () {};
 const y = function ident () {};
+
+export default function test() {
+}
+export default function () {
+}


### PR DESCRIPTION
Closes https://github.com/dprint/dprint-plugin-typescript/issues/642