### PR TITLE
fix(fmt): Preserve single-line objects in array formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "dprint-development",
  "percent-encoding",
  "pretty_assertions",
+ "regex",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ percent-encoding = "2.3.1"
 rustc-hash = "1.1.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+regex = "1.10.4"
 
 [dev-dependencies]
 dprint-development = "0.10.1"

--- a/tests/specs/issues/issue0641.txt
+++ b/tests/specs/issues/issue0641.txt
@@ -1,0 +1,10 @@
+== Array of objects is not formatted nicely ==
+const fpnMembershipTitles = [{ name: "FPN" }, { name: "FPN Class" }, { name: "Type" }, { name: "Description" }];
+
+[expect]
+const fpnMembershipTitles = [
+    { name: "FPN" },
+    { name: "FPN Class" },
+    { name: "Type" },
+    { name: "Description" },
+];


### PR DESCRIPTION
fix #641
&& https://github.com/denoland/deno/issues/22459