### PR TITLE
fix: trailing comments sometimes being inserted before the comma in parameter lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "dprint-core",
  "dprint-core-macros",
  "dprint-development",
+ "dprint-swc-ext",
  "percent-encoding",
  "pretty_assertions",
  "rustc-hash",
@@ -245,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ext"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0d5b63e52434314e3d767c463b1f68c467c31e61d279bc019227016c44e535"
+checksum = "2b909f9f9b22a6265839887544dce97b0b8e2b2635abf622f45613deb3de63e0"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ anyhow = "1.0.64"
 deno_ast = { version = "0.40.0", features = ["view"] }
 dprint-core = { version = "0.66.2", features = ["formatting"] }
 dprint-core-macros = "0.1.0"
+# temp until https://github.com/swc-project/swc/issues/9290 is fixed
+dprint-swc-ext = "0.17.1"
 percent-encoding = "2.3.1"
 rustc-hash = "1.1.0"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -26,8 +26,8 @@ use crate::configuration::*;
 use crate::utils;
 
 pub fn generate(parsed_source: &ParsedSource, config: &Configuration) -> PrintItems {
-  // println!("Leading: {:?}", parsed_source.comments().leading_map());
-  // println!("Trailing: {:?}", parsed_source.comments().trailing_map());
+  // eprintln!("Leading: {:?}", parsed_source.comments().leading_map());
+  // eprintln!("Trailing: {:?}", parsed_source.comments().trailing_map());
 
   parsed_source.with_view(|program| {
     let program_node = program.into();
@@ -52,13 +52,13 @@ fn gen_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItems {
 
 fn gen_node_with_inner_gen<'a>(node: Node<'a>, context: &mut Context<'a>, inner_gen: impl FnOnce(PrintItems, &mut Context<'a>) -> PrintItems) -> PrintItems {
   let node_kind = node.kind();
-  // println!("Node kind: {:?}", node_kind);
-  // println!("Text: {:?}", node.text());
-  // println!("Range: {:?}", node.range());
+  // eprintln!("Node kind: {:?}", node_kind);
+  // eprintln!("Text: {:?}", node.text());
+  // eprintln!("Range: {:?}", node.range());
 
   // store info
   let past_current_node = std::mem::replace(&mut context.current_node, node);
-  let parent_hi = past_current_node.end();
+  let parent_end = past_current_node.end();
   context.parent_stack.push(past_current_node);
 
   // handle decorators (since their starts can come before their parent)
@@ -110,7 +110,7 @@ fn gen_node_with_inner_gen<'a>(node: Node<'a>, context: &mut Context<'a>, inner_
 
   // Get the trailing comments -- This needs to be done based on the parse
   // stack order because certain nodes like binary expressions are flattened
-  if node_end != parent_hi || matches!(context.parent().kind(), NodeKind::Module | NodeKind::Script) {
+  if node_end != parent_end || matches!(context.parent().kind(), NodeKind::Module | NodeKind::Script) {
     let trailing_comments = context.comments.trailing_comments_with_previous(node_end);
     items.extend(gen_comments_as_trailing(&node_range, trailing_comments, context));
   }

--- a/tests/specs/issues/issue0650.txt
+++ b/tests/specs/issues/issue0650.txt
@@ -1,0 +1,52 @@
+~~ lineWidth: 120, indentWidth: 2 ~~
+== should work ==
+function foo(arg: number, /** @deferred */ b) {}
+
+[expect]
+function foo(arg: number, /** @deferred */ b) {}
+
+== interface method ==
+interface A {
+  b(
+    arg1: { new(...args: any[]): T }, // This is a comment
+    arg2,
+  )
+}
+
+[expect]
+interface A {
+  b(
+    arg1: { new(...args: any[]): T }, // This is a comment
+    arg2,
+  );
+}
+
+== long example ==
+function foo(arg: number, /** @deferred */ cb: () => void): void {}
+
+interface Foo {
+  method<T>(
+    arg: { new(...args: any[]): T }, // This is a comment
+    arg2: (instance: T) => HTMLElement | undefined,
+  ): Disposable;
+
+  method2<T>(
+    arg: { new(...args: any[]): T },
+    arg2: (instance: T) => HTMLElement | undefined, // This is a comment
+  ): Disposable;
+}
+
+[expect]
+function foo(arg: number, /** @deferred */ cb: () => void): void {}
+
+interface Foo {
+  method<T>(
+    arg: { new(...args: any[]): T }, // This is a comment
+    arg2: (instance: T) => HTMLElement | undefined,
+  ): Disposable;
+
+  method2<T>(
+    arg: { new(...args: any[]): T },
+    arg2: (instance: T) => HTMLElement | undefined, // This is a comment
+  ): Disposable;
+}


### PR DESCRIPTION
Closes https://github.com/dprint/dprint-plugin-typescript/issues/650