### PR TITLE
fix: revert back default type only named imports/exports sorting to "none"

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -300,7 +300,7 @@
     "typeOnlyImportsExportsSortOrder": {
       "description": "The kind of sort ordering to use for typed imports and exports.",
       "type": "string",
-      "default": "last",
+      "default": "none",
       "oneOf": [{
         "const": "first",
         "description": "Puts type-only named imports and exports first."

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -69,8 +69,8 @@ impl ConfigurationBuilder {
       .ignore_file_comment_text("deno-fmt-ignore-file")
       .module_sort_import_declarations(SortOrder::Maintain)
       .module_sort_export_declarations(SortOrder::Maintain)
-      .export_declaration_sort_type_only_exports(NamedTypeImportsExportsOrder::Last)
-      .import_declaration_sort_type_only_imports(NamedTypeImportsExportsOrder::Last)
+      .export_declaration_sort_type_only_exports(NamedTypeImportsExportsOrder::None)
+      .import_declaration_sort_type_only_imports(NamedTypeImportsExportsOrder::None)
   }
 
   /// The width of a line the printer will try to stay under. Note that the printer may exceed this width in certain cases.

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -122,13 +122,13 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     import_declaration_sort_type_only_imports: get_value(
       &mut config,
       "importDeclaration.sortTypeOnlyImports",
-      NamedTypeImportsExportsOrder::Last,
+      NamedTypeImportsExportsOrder::None,
       &mut diagnostics,
     ),
     export_declaration_sort_type_only_exports: get_value(
       &mut config,
       "exportDeclaration.sortTypeOnlyExports",
-      NamedTypeImportsExportsOrder::Last,
+      NamedTypeImportsExportsOrder::None,
       &mut diagnostics,
     ),
     /* ignore comments */

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -300,8 +300,8 @@ generate_str_to_from![
 #[serde(rename_all = "camelCase")]
 pub enum NamedTypeImportsExportsOrder {
   First,
-  #[default]
   Last,
+  #[default]
   None,
 }
 

--- a/tests/specs/declarations/export/NamedExports_SortOrder_CaseInsensitive.txt
+++ b/tests/specs/declarations/export/NamedExports_SortOrder_CaseInsensitive.txt
@@ -73,7 +73,7 @@ export { // test
     testing,
 } from "asdf";
 
-== should sort type imports last by default ==
+== should not sort type imports by default in order to reduce merge conflicts ==
 export {
     type a,
     testing,
@@ -84,9 +84,9 @@ export {
 
 [expect]
 export {
+    type a,
     other,
     outttttttttttttttt,
     testing,
-    type a,
     type z,
 } from "asdf";

--- a/tests/specs/declarations/import/NamedImports_SortOrder_CaseInsensitive.txt
+++ b/tests/specs/declarations/import/NamedImports_SortOrder_CaseInsensitive.txt
@@ -73,20 +73,20 @@ import { // test
     testing,
 } from "asdf";
 
-== should sort with types last ==
+== should not sort type only imports by default to reduce merge conflicts ==
 import {
     type a,
     testing,
     other,
     outttttttttttttttt,
-    type b,
+    type z,
 } from "asdf";
 
 [expect]
 import {
+    type a,
     other,
     outttttttttttttttt,
     testing,
-    type a,
-    type b,
+    type z,
 } from "asdf";


### PR DESCRIPTION
I think this should be off by default to the chance of merge conflicts. People rarely look at named imports/exports.