### PR TITLE
Do not move assignment value on new line if `variable_statement_prefer_single_line` is `true`

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -9177,7 +9177,9 @@ fn gen_assignment_like_with_token<'a>(expr: Node<'a>, op: &'static StringContain
         {
           let mut items = PrintItems::new();
           items.push_signal(Signal::SpaceIfNotTrailing);
-          items.push_signal(Signal::PossibleNewLine);
+          if context.config.variable_statement_prefer_single_line {
+              items.push_signal(Signal::PossibleNewLine);
+          }
           items
         },
         Signal::SpaceIfNotTrailing.into(),


### PR DESCRIPTION
Before
```ts
let str = 
	"relative m-t-auto mb8 h12 wfull font-bold c-white rounded-43px border-style-none bg-blue-450 shrink-0 dark:disabled:(bg-blue-900! c-blue-700) light:disabled:(bg-blue-100! c-blue-000) active:bg-blue-450/80 cursor-pointer"
```
After
```ts
let str = "relative m-t-auto mb8 h12 wfull font-bold c-white rounded-43px border-style-none bg-blue-450 shrink-0 dark:disabled:(bg-blue-900! c-blue-700) light:disabled:(bg-blue-100! c-blue-000) active:bg-blue-450/80 cursor-pointer"
```