### PR TITLE
feat: ability to format a file at a specific indentation level

### DIFF
--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -203,6 +203,15 @@ impl ConfigurationBuilder {
     self.insert("singleBodyPosition", value.to_string().into())
   }
 
+  /// Amount of indents to use for the whole file.
+  ///
+  /// This should only be set by tools that need to indent all the code in the file.
+  ///
+  /// Default: `0`
+  pub fn file_indent_level(&mut self, value: u16) -> &mut Self {
+    self.insert("fileIndentLevel", (value as i32).into())
+  }
+
   /// If trailing commas should be used.
   ///
   /// Default: `TrailingCommas::OnlyMultiLine`
@@ -1105,6 +1114,7 @@ mod tests {
       .operator_position(OperatorPosition::SameLine)
       .single_body_position(SameOrNextLinePosition::SameLine)
       .trailing_commas(TrailingCommas::Never)
+      .file_indent_level(1)
       .use_braces(UseBraces::WhenNotSingleLine)
       .quote_props(QuoteProps::AsNeeded)
       .prefer_hanging(false)
@@ -1287,7 +1297,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 181);
+    assert_eq!(inner_config.len(), 182);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -92,6 +92,7 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     quote_style,
     quote_props,
     semi_colons,
+    file_indent_level: get_value(&mut config, "fileIndentLevel", 0, &mut diagnostics),
     /* situational */
     arrow_function_use_parentheses: get_value(&mut config, "arrowFunction.useParentheses", UseParentheses::Maintain, &mut diagnostics),
     binary_expression_line_per_expression: get_value(&mut config, "binaryExpression.linePerExpression", false, &mut diagnostics),

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -317,6 +317,7 @@ pub struct Configuration {
   pub quote_style: QuoteStyle,
   pub quote_props: QuoteProps,
   pub semi_colons: SemiColons,
+  pub file_indent_level: u32,
   /* situational */
   #[serde(rename = "arrowFunction.useParentheses")]
   pub arrow_function_use_parentheses: UseParentheses,

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -42,7 +42,11 @@ pub fn generate(parsed_source: &ParsedSource, config: &Configuration) -> PrintIt
     #[cfg(debug_assertions)]
     context.assert_end_of_file_state();
 
-    items
+    if config.file_indent_level > 0 {
+      with_indent_times(items, config.file_indent_level)
+    } else {
+      items
+    }
   })
 }
 

--- a/tests/specs/file_indent_level/FileIndentLevel.txt
+++ b/tests/specs/file_indent_level/FileIndentLevel.txt
@@ -1,0 +1,16 @@
+~~ fileIndentLevel: 4 ~~
+== formats with indentation ==
+const test = `this
+
+is a multiline string
+
+`;
+console.log(test);
+
+[expect]
+                const test = `this
+
+is a multiline string
+
+`;
+                console.log(test);


### PR DESCRIPTION
This is for plugins like https://github.com/g-plane/markup_fmt when they need to format at a specific indentation level for stuff like `<script>` tags.

Todo: investigate naming