### PR TITLE
fix: external formatter should be able to handle tab characters

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3051,7 +3051,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
       }
       let text = &line[pos..end];
       if !text.is_empty() {
-        items.push_string(text.to_string());
+        items.extend(gen_from_raw_string(text));
       }
       if parts.peek().is_some() {
         items.push_sc(sc!("${"));


### PR DESCRIPTION
Fixes #709

Also, wasn't able to create a spec for this change, as the current testing is not flexible enough to add custom configurations on a per case basis. It also seems like since the spec parsing is part of `dprint_core`, I'm assuming that change might be massive.