### PR TITLE
fix: handle backslashes in embedded template language reasonably

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -165,6 +165,9 @@ mod test {
       }),
     });
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().to_string(), "Error formatting tagged template literal at line 0: Syntax error from external formatter");
+    assert_eq!(
+      result.unwrap_err().to_string(),
+      "Error formatting tagged template literal at line 0: Syntax error from external formatter"
+    );
   }
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3038,8 +3038,8 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   .unwrap();
 
   // Then formats the text with the external formatter.
-  let formatted_tpl = match external_formatter(media_type, text, context.config) {
-    Ok(formatted_tpl) => formatted_tpl?,
+  let formatted_tpl = match external_formatter(media_type, text.replace(r"\\", "\\"), context.config) {
+    Ok(formatted_tpl) => formatted_tpl?.replace("\\", r"\\"),
     Err(err) => {
       context.diagnostics.push(context::GenerateDiagnostic {
         message: format!("Error formatting tagged template literal at line {}: {}", node.start_line(), err),

--- a/tests/specs/external_formatter/css.txt
+++ b/tests/specs/external_formatter/css.txt
@@ -122,3 +122,12 @@ styled.div`color:red;`;
 [expect]
 // dprint-ignore
 styled.div`color:red;`;
+
+== should format css that includes \\ ==
+css`.bg-\\[\\#86efac\\] { background-color: #86efac; }`
+[expect]
+css`
+    .bg-\\[\\#86efac\\] {
+        background-color: #86efac;
+    }
+`;


### PR DESCRIPTION
closes #713 

This PR updates the handling of template literals with embedded langauges.

This change unescape `\\` sequence before applying external formatters, and escape it back after it.

Some css classes needs to use `\` to escape it in css level, and that becomes `\\` in template literals. The use of `\\` causes syntax error in css formatter (malva, See https://github.com/g-plane/malva/issues/35 ). This change avoids that error.