### PR TITLE
fix: handling of indent inside embedded language

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3058,7 +3058,27 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   items.push_signal(Signal::NewLine);
   items.push_signal(Signal::StartIndent);
   let mut index = 0;
+  let mut current_indent_level = 0;
+  let indent_width = context.config.indent_width;
+  let indent_str = if context.config.use_tabs { '\t' } else { ' ' };
   for line in formatted_tpl.lines() {
+    let mut indent = 0_usize;
+    for c in line.chars() {
+      if c == indent_str {
+        indent += 1;
+      } else {
+        break;
+      }
+    }
+    let indent_level = indent / indent_width as usize;
+    if indent_level > current_indent_level {
+      items.push_signal(Signal::StartIndent);
+      current_indent_level = indent_level;
+    } else if indent_level < current_indent_level {
+      items.push_signal(Signal::FinishIndent);
+      current_indent_level = indent_level;
+    }
+    let line = &line[indent..];
     let mut pos = 0;
     let mut parts = line.split(placeholder_text).enumerate().peekable();
     while let Some((i, part)) = parts.next() {
@@ -3079,6 +3099,10 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
       }
     }
     items.push_signal(Signal::NewLine);
+  }
+  while current_indent_level > 0 {
+    items.push_signal(Signal::FinishIndent);
+    current_indent_level -= 1;
   }
   items.push_signal(Signal::FinishIndent);
   items.push_sc(sc!("`"));

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3065,7 +3065,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   for line in formatted_tpl.lines() {
     // count indent characters
     let mut pos = line.chars().take_while(|ch| *ch == indent_char).count();
-    let indent_level = pos / indent_width as usize;
+    let indent_level = if index_width == 0 { 0 } else { pos / indent_width as usize };
     if indent_level > current_indent_level {
       items.push_signal(Signal::StartIndent);
       current_indent_level = indent_level;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3012,10 +3012,6 @@ fn gen_spread_element<'a>(node: &SpreadElement<'a>, context: &mut Context<'a>) -
   items
 }
 
-fn count_indent_char(line: &str, c: char) -> usize {
-  line.chars().take_while(|ch| *ch == c).count()
-}
-
 /// Formats the tagged template literal using an external formatter.
 /// Detects the type of embedded language automatically.
 fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, context: &mut Context<'a>) -> Option<PrintItems> {
@@ -3067,7 +3063,8 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   let indent_width = if use_tabs { 1 } else { context.config.indent_width };
   let indent_char = if use_tabs { '\t' } else { ' ' };
   for line in formatted_tpl.lines() {
-    let mut pos = count_indent_char(line, indent_char);
+    // count indent characters
+    let mut pos = line.chars().take_while(|ch| *ch == indent_char).count();
     let indent_level = pos / indent_width as usize;
     if indent_level > current_indent_level {
       items.push_signal(Signal::StartIndent);

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3065,7 +3065,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   for line in formatted_tpl.lines() {
     // count indent characters
     let mut pos = line.chars().take_while(|ch| *ch == indent_char).count();
-    let indent_level = if index_width == 0 { 0 } else { pos / indent_width as usize };
+    let indent_level = if indent_width == 0 { 0 } else { pos / indent_width as usize };
     if indent_level > current_indent_level {
       items.push_signal(Signal::StartIndent);
       current_indent_level = indent_level;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3071,8 +3071,9 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   items.push_signal(Signal::StartIndent);
   let mut index = 0;
   let mut current_indent_level = 0;
-  let indent_width = context.config.indent_width;
-  let indent_char = if context.config.use_tabs { '\t' } else { ' ' };
+  let use_tabs = context.config.use_tabs;
+  let indent_width = if use_tabs { 1 } else { context.config.indent_width };
+  let indent_char = if use_tabs { '\t' } else { ' ' };
   for line in formatted_tpl.lines() {
     let mut pos = count_indent_char(line, indent_char);
     let indent_level = pos / indent_width as usize;

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3013,15 +3013,7 @@ fn gen_spread_element<'a>(node: &SpreadElement<'a>, context: &mut Context<'a>) -
 }
 
 fn count_indent_char(line: &str, c: char) -> usize {
-  let mut indent = 0;
-  for ch in line.chars() {
-    if ch == c {
-      indent += 1;
-    } else {
-      break;
-    }
-  }
-  indent
+  line.chars().take_while(|ch| *ch == c).count()
 }
 
 /// Formats the tagged template literal using an external formatter.

--- a/tests/specs/external_formatter/html.txt
+++ b/tests/specs/external_formatter/html.txt
@@ -20,7 +20,7 @@ htmlString = html`
     </body>
 `;
 
-== should format nexted html templates with correct indent level ==
+== should format nested html templates with correct indent level ==
 export const Layout = (props: Props) => html`
   <html>
     <body>

--- a/tests/specs/external_formatter/html.txt
+++ b/tests/specs/external_formatter/html.txt
@@ -19,3 +19,33 @@ htmlString = html`
         <footer>${footer}</footer>
     </body>
 `;
+
+== should format nexted html templates with correct indent level ==
+export const Layout = (props: Props) => html`
+  <html>
+    <body>
+      ${props.title.endsWith("example")
+        ? html`
+            <a href="/">Reactive Mastro examples</a>
+            <h1>${props.title}</h1>
+            `
+        : ""}
+      <main>${props.children}</main>
+    </body>
+  </html>
+  `;
+[expect]
+export const Layout = (props: Props) =>
+    html`
+        <html>
+            <body>
+                ${props.title.endsWith("example")
+                    ? html`
+                        <a href="/">Reactive Mastro examples</a>
+                        <h1>${props.title}</h1>
+                    `
+                    : ""}
+                <main>${props.children}</main>
+            </body>
+        </html>
+    `;


### PR DESCRIPTION
This PR fixes the handling of indent inside the template literals with embedded languages.

Currently the leading whitespaces in the line of embedded external languages are handled as part of source code, and that causes the issue https://github.com/denoland/deno/issues/29164 . This PR fixes it by skipping the leading whitespaces, but instead adding `StartIndent` and `FinishIndent` IR signals based on current indent level of the embedded language.

related https://github.com/denoland/deno/issues/29164