### PR TITLE
fix: line number in syntax error message from external formatter

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -167,7 +167,7 @@ mod test {
     assert!(result.is_err());
     assert_eq!(
       result.unwrap_err().to_string(),
-      "Error formatting tagged template literal at line 0: Syntax error from external formatter"
+      "Error formatting tagged template literal at line 1: Syntax error from external formatter"
     );
   }
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3047,7 +3047,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
     Ok(formatted_tpl) => formatted_tpl?.replace("\\", r"\\"),
     Err(err) => {
       context.diagnostics.push(context::GenerateDiagnostic {
-        message: format!("Error formatting tagged template literal at line {}: {}", node.start_line(), err),
+        message: format!("Error formatting tagged template literal at line {}: {}", node.start_line() + 1, err),
       });
       return None;
     }


### PR DESCRIPTION
This fixes the line number in error message when external formatter raised syntax error

related: https://github.com/denoland/deno/issues/29660#issuecomment-2954240031