### PR TITLE
refactor(BREAKING): external formatter accepts string instead of MediaType

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -159,8 +159,8 @@ mod test {
       extension: None,
       text: "const content = html`<div>broken html</p>`".into(),
       config: &config,
-      external_formatter: Some(&|media_type, _text, _config| {
-        assert!(matches!(media_type, deno_ast::MediaType::Html));
+      external_formatter: Some(&|lang, _text, _config| {
+        assert!(matches!(lang, "html"));
         Err(anyhow::anyhow!("Syntax error from external formatter"))
       }),
     });

--- a/src/generation/context.rs
+++ b/src/generation/context.rs
@@ -18,9 +18,10 @@ use super::*;
 use crate::configuration::*;
 use crate::utils::Stack;
 
-/// A callback that will be called when encountering certain tagged templates.
+/// A callback that will be called when encountering tagged templates.
 ///
-/// Currently supports `css`, `html` and `sql` tagged templated.
+/// It is up to the caller to decide if a certain tagged template should be formatted
+/// by the external formatter.
 ///
 /// Examples:
 /// ```ignore
@@ -41,11 +42,11 @@ use crate::utils::Stack;
 ///   active IS TRUE;
 /// ```
 ///
-/// External formatter should return `None` if it doesn't understand given `MediaType`, in such
+/// External formatter should return `None` if it doesn't understand given language, in such
 /// cases the templates will be left as they are.
 ///
 /// Only templates with no interpolation are supported.
-pub type ExternalFormatter = dyn Fn(MediaType, String, &Configuration) -> anyhow::Result<Option<String>>;
+pub type ExternalFormatter = dyn Fn(&str, String, &Configuration) -> anyhow::Result<Option<String>>;
 
 pub(crate) struct GenerateDiagnostic {
   pub message: String,

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -2,18 +2,17 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use deno_ast::MediaType;
 use dprint_core::configuration::*;
 use dprint_development::*;
 use dprint_plugin_typescript::configuration::*;
 use dprint_plugin_typescript::*;
 
-fn external_formatter(media_type: MediaType, text: String, config: &Configuration) -> Result<Option<String>> {
-  match media_type {
-    MediaType::Css => format_embedded_css(&text, config),
-    MediaType::Html => format_html(&text, config),
-    MediaType::Sql => format_sql(&text, config),
-    _ => unreachable!(),
+fn external_formatter(lang: &str, text: String, config: &Configuration) -> Result<Option<String>> {
+  match lang {
+    "css" => format_embedded_css(&text, config),
+    "html" => format_html(&text, config),
+    "sql" => format_sql(&text, config),
+    _ => Ok(None),
   }
 }
 


### PR DESCRIPTION
Working on https://github.com/denoland/deno/pull/29851#discussion_r2162069234
I realized it's not possible to support any tagged template without first
updating `dprint-plugin-typescript` and possibly `deno_media_type`.