### PR TITLE
fix(jsx): avoid making type param lists ambiguous when trailingCommas is never

### DIFF
--- a/tests/specs/general/Jsx_TrailingCommas.txt
+++ b/tests/specs/general/Jsx_TrailingCommas.txt
@@ -6,12 +6,12 @@ const Test2 = function<T,>() {};
 const Test1 = <T>() => false;
 const Test2 = function<T>() {};
 
-== should keep trailing comma in expression type parameters in file parsed as jsx since there is no parsing ambiguity ==
+== should keep trailing comma in expression type parameters in file parsed as jsx since there is parsing ambiguity ==
 const Test1 = <T,>() => false;
-const Test2 = function<T,>() {};
-const Test3 = <div></div>;
+const Test2 = <div></div>;
 
-// not for declarations though
+// not for function declarations or expressions though
+const Test3 = function<T,>() {};
 function test<T,>() {
 }
 
@@ -27,10 +27,10 @@ const Test5 = <P extends R<S, T>>() => {};
 
 [expect]
 const Test1 = <T,>() => false;
-const Test2 = function<T,>() {};
-const Test3 = <div></div>;
+const Test2 = <div></div>;
 
-// not for declarations though
+// not for function declarations or expressions though
+const Test3 = function<T>() {};
 function test<T>() {
 }
 

--- a/tests/specs/general/Jsx_TrailingCommas_Never.txt
+++ b/tests/specs/general/Jsx_TrailingCommas_Never.txt
@@ -1,0 +1,23 @@
+-- file.tsx --
+~~ trailingCommas: never ~~
+== should never trim trailing commas from single type parameters in expressions ==
+const test1: <T,>(t: T) => T = <T,>(t: T) => t;
+export default <T,>(t: T) => t;
+[].filter(<T,>() => false);
+const test2 = function<T,>(t: T) { };
+const test3 = class<T,> { };
+
+// an extends clause ought to be enough to resolve the ambiguity
+const test4 = function<T extends unknown>(t: T) {};
+const test5 = class<T extends unknown> {};
+
+[expect]
+const test1: <T>(t: T) => T = <T,>(t: T) => t;
+export default <T,>(t: T) => t;
+[].filter(<T,>() => false);
+const test2 = function<T>(t: T) {};
+const test3 = class<T> {};
+
+// an extends clause ought to be enough to resolve the ambiguity
+const test4 = function<T extends unknown>(t: T) {};
+const test5 = class<T extends unknown> {};


### PR DESCRIPTION
Hello, this is the first Rust I've ever read/written. I'd like to fix #636. The guards against mangling type parameter lists were in place but deactivated by `trailingCommas: never`. Change it to always check before applying the preferred style.

I noticed it checked for `function<T>` as well, but in my testing neither function expressions nor declarations are ambiguous:

```typescript
// These parse correctly even in TSX
function foo<T>() { }
const foo = function<T>() {}
class foo<T>() { }
const foo = class<T>() {}
```

The presence of the `function` or `class` keywords seems to be enough for the TypeScript parser to disambiguate.

Thank you, dprint and its plugins are such a delight.