### PR TITLE
fix issues 686 and 753

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -9811,8 +9811,8 @@ fn allows_inline_multi_line<'a>(node: Node<'a>, context: &Context<'a>, has_sibli
           _ => allows_inline_multi_line(as_expr.type_ann.into(), context, has_siblings),
         }
     }
+    Node::ArrowExpr(arrow) => matches!(arrow.body, BlockStmtOrExpr::BlockStmt(_)),
     Node::FnExpr(_)
-    | Node::ArrowExpr(_)
     | Node::ObjectLit(_)
     | Node::ArrayLit(_)
     | Node::ObjectPat(_)

--- a/tests/specs/issues/issue0686.txt
+++ b/tests/specs/issues/issue0686.txt
@@ -1,0 +1,45 @@
+~~ lineWidth: 80, indentWidth: 2, memberExpression.linePerExpression: true ~~
+== generator ==
+const createTestData = () =>
+  function*() {
+    const startingFrom = yield* Effect.map(DateTime.now, now => DateTime.startOf(now, "day"))
+
+    return HashSet.make(DateTime.toEpochMillis(startingFrom))
+  };
+
+
+[expect]
+const createTestData = () =>
+  function*() {
+    const startingFrom = yield* Effect.map(
+      DateTime.now,
+      now => DateTime.startOf(now, "day"),
+    );
+
+    return HashSet.make(DateTime.toEpochMillis(startingFrom));
+  };
+
+== function ==
+const func = () =>
+  function() {
+    const startingFrom = Effect.map(DateTime.now, now => DateTime.startOf(now, 'day'))
+
+    return myObj
+      .myMethod({
+        missionType: otherObj.prop.nested,
+      });
+  };
+
+[expect]
+const func = () =>
+  function() {
+    const startingFrom = Effect.map(
+      DateTime.now,
+      now => DateTime.startOf(now, "day"),
+    );
+
+    return myObj
+      .myMethod({
+        missionType: otherObj.prop.nested,
+      });
+  };

--- a/tests/specs/issues/issue0753.txt
+++ b/tests/specs/issues/issue0753.txt
@@ -1,0 +1,46 @@
+~~ lineWidth: 80, indentWidth: 2, memberExpression.linePerExpression: true ~~
+== function args ==
+const startingFrom = Mylib.map(DateTime.now, now => DateTime.startOf(now, "day"))
+
+const func = () =>
+  function() {
+    const startingFrom = Mylib.map(DateTime.now, now => DateTime.startOf(now, "day"))
+  }
+
+
+[expect]
+const startingFrom = Mylib.map(
+  DateTime.now,
+  now => DateTime.startOf(now, "day"),
+);
+
+const func = () =>
+  function() {
+    const startingFrom = Mylib.map(
+      DateTime.now,
+      now => DateTime.startOf(now, "day"),
+    );
+  };
+
+== function args same line length ==
+const startingFroom = Mylib.map(DateTime.now, now => DateTime.startOf(now, "day"))
+
+const func = () =>
+  function() {
+    const startingF = Mylib.map(DateTime.now, now => DateTime.startOf(now, "day"))
+  }
+
+
+[expect]
+const startingFroom = Mylib.map(
+  DateTime.now,
+  now => DateTime.startOf(now, "day"),
+);
+
+const func = () =>
+  function() {
+    const startingF = Mylib.map(
+      DateTime.now,
+      now => DateTime.startOf(now, "day"),
+    );
+  };


### PR DESCRIPTION
Modified `src/generation/generate.rs` to return `false` for `Node::ArrowExpr` in `allows_inline_multi_line` unless the arrow function body is a block statement. This prevents arrow functions with expression bodies from being formatted inline when they overflow, ensuring consistent multi-line formatting for function arguments. Verified with regression tests.

NOTE: this PR was created with the assistance from an AI agent, see original PR on my for which was created by the agent: https://github.com/adrian-gierakowski/dprint-plugin-typescript/pull/2

Fixes https://github.com/dprint/dprint-plugin-typescript/issues/753
Fixes https://github.com/dprint/dprint-plugin-typescript/issues/686