### PR TITLE
fix: remove needless parens in key value prop value

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -2916,6 +2916,7 @@ fn should_skip_paren_expr<'a>(node: &'a ParenExpr<'a>, context: &Context<'a>) ->
       | NodeKind::JSXExprContainer
       | NodeKind::UpdateExpr
       | NodeKind::ComputedPropName
+      | NodeKind::KeyValueProp
   ) {
     return true;
   }

--- a/tests/specs/expressions/ObjectProperty/ObjectProperty_All.txt
+++ b/tests/specs/expressions/ObjectProperty/ObjectProperty_All.txt
@@ -29,3 +29,25 @@ function test() {
         },
     };
 }
+
+== should remove needless parens ==
+const obj = {
+    prop: ({ a, b } = obj)
+}
+
+const obj = {
+    prop   , // test
+    prop2   :    (2),
+    prop3 : (foo()),
+};
+
+[expect]
+const obj = {
+    prop: ({ a, b } = obj),
+};
+
+const obj = {
+    prop, // test
+    prop2: 2,
+    prop3: foo(),
+};


### PR DESCRIPTION
- Modified ```src/generation/generate.rs``` , adding KeyValueProp as a skip to fix #765 
- Add relevant test to ```tests/specs/expressions/ObjectProperty/ObjectProperty_All.txt