### PR TITLE
Add support for .gs (Google App Script) files

### DIFF
--- a/src/swc.rs
+++ b/src/swc.rs
@@ -15,7 +15,7 @@ pub fn parse_swc_ast(file_path: &Path, file_extension: Option<&str>, file_text: 
       let lowercase_ext = file_extension.map(|ext| ext.to_string()).or_else(|| get_lowercase_extension(file_path));
       let new_file_path = match lowercase_ext.as_deref() {
         Some("ts") | Some("cts") | Some("mts") => file_path.with_extension("tsx"),
-        Some("js") | Some("cjs") | Some("mjs") => file_path.with_extension("jsx"),
+        Some("js") | Some("cjs") | Some("mjs") | Some("gs") => file_path.with_extension("jsx"),
         _ => return Err(err),
       };
       // try to parse as jsx

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -32,6 +32,8 @@ impl SyncPluginHandler<Configuration> for TypeScriptPluginHandler {
           String::from("cjs"),
           String::from("mts"),
           String::from("cts"),
+          // Google App Script
+          String::from("gs"),
         ],
         file_names: vec![],
       },


### PR DESCRIPTION
Treat `.gs` ([Google App Script](https://script.google.com/home)) files as javascript files.