### PR TITLE
fix: handle multi-character binary operators split by SWC's lexer

### DIFF
--- a/src/generation/swc/flatten_binary_expr.rs
+++ b/src/generation/swc/flatten_binary_expr.rs
@@ -22,7 +22,7 @@ pub struct BinExprOp<'a> {
 pub fn get_flattened_bin_expr<'a, 'b>(node: &'b BinExpr<'a>, context: &mut Context<'a>) -> Vec<BinExprItem<'a>> {
   let mut items = Vec::new();
   let operator_token = BinExprOp {
-    token: context.token_finder.get_first_operator_after(&node.left, node.op().as_str()).unwrap(),
+    token: find_operator_token_after(&node.left, node.op(), context),
     op: node.op(),
   };
   let is_op_same_line = get_operator_position(node, operator_token.token, context) == OperatorPosition::SameLine;
@@ -67,6 +67,29 @@ pub fn get_flattened_bin_expr<'a, 'b>(node: &'b BinExpr<'a>, context: &mut Conte
   }
 
   return items;
+
+  /// Locate the binary operator's leading token, immediately after the left
+  /// operand. Most of the time this is just `get_first_operator_after` with
+  /// the operator's full text (e.g. `<=`), but the SWC lexer can split
+  /// multi-character operators into separate tokens when the operator
+  /// follows a TypeScript type position. For example `0 as number <= 1`
+  /// tokenizes `<=` as `<` then `=`. In that case we fall back to matching
+  /// just the operator's first character (`<`), which is always a single
+  /// token whose start position is what callers actually need (e.g. for
+  /// `start_line_fast`).
+  fn find_operator_token_after<'a>(left: &impl SourceRanged, op: BinaryOp, context: &mut Context<'a>) -> &'a TokenAndSpan {
+    let op_text = op.as_str();
+    if let Some(tok) = context.token_finder.get_first_operator_after(left, op_text) {
+      return tok;
+    }
+    if op_text.len() > 1 {
+      let first_char_text = &op_text[..1];
+      if let Some(tok) = context.token_finder.get_first_operator_after(left, first_char_text) {
+        return tok;
+      }
+    }
+    panic!("could not locate operator token for binary op `{op_text}`");
+  }
 
   fn is_expression_breakable(top_op: BinaryOp, op: BinaryOp) -> bool {
     if top_op.is_add_sub() {

--- a/tests/specs/expressions/BinaryExpression/BinaryExpression_All.txt
+++ b/tests/specs/expressions/BinaryExpression/BinaryExpression_All.txt
@@ -286,3 +286,15 @@ const test =
 const test =
     // testing
     a + b + c;
+
+== should format multi-character comparison after a TS as-expression (LtEq) ==
+0 as number <= 1;
+
+[expect]
+0 as number <= 1;
+
+== should format multi-character comparison after a TS as-expression (GtEq) ==
+0 as number >= 1;
+
+[expect]
+0 as number >= 1;


### PR DESCRIPTION
## Summary

`0 as number <= 1` panics dprint-plugin-typescript with:

```
thread 'main' panicked at flatten_binary_expr.rs:25:
called `Option::unwrap()` on a `None` value
```

The SWC lexer tokenizes multi-character binary operators as **separate** tokens when the operator follows a TypeScript type position. For `0 as number <= 1`, after parsing the type `number` the lexer emits `<` and `=` as two tokens instead of a single `<=` token — even though the parser's expression layer still produces one `<=` BinExpr. `get_flattened_bin_expr` was searching for a single token whose text equals `node.op().as_str()` ("<="), found none, and unwrapped.

Confirmed via deno_ast: tokens for `0 as number <= 1` are `0`, `as`, `number`, `<`, `=`, `1`, `;`. There's already a `should print swc issue where it didn't tokenize << correctly here` case in `BinaryExpression_All.txt`, so this is a class of bug the lexer has had before.

Move the operator-token lookup into a small helper and, when matching the full operator text fails, fall back to matching just the operator's first character. The fallback is sufficient because the only thing callers need from the token is its start position (e.g. `start_line_fast` for `OperatorPosition` decisions) — the leading `<` token has the same start as the conceptual `<=` operator.

This fixes `<=`, `>=`, and any other multi-character relational operator that lands in the lexer's TS-type-aware mode.

Reported in denoland/deno#31988.

## Test plan

- Added two cases to `tests/specs/expressions/BinaryExpression/BinaryExpression_All.txt` exercising `0 as number <= 1` and `0 as number >= 1`. Both panic on `main` and round-trip cleanly with this change.
- All 647 existing specs continue to pass: `cargo test --test specs`.
- `rustfmt --check` clean on the modified file.