### PR TITLE
fix: balance indent signals on multi-level jumps in embedded tagged templates

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3087,12 +3087,13 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
     // count indent characters
     let mut pos = line.chars().take_while(|ch| *ch == indent_char).count();
     let indent_level = if indent_width == 0 { 0 } else { pos / indent_width as usize };
-    if indent_level > current_indent_level {
+    while indent_level > current_indent_level {
       items.push_signal(Signal::StartIndent);
-      current_indent_level = indent_level;
-    } else if indent_level < current_indent_level {
+      current_indent_level += 1;
+    }
+    while indent_level < current_indent_level {
       items.push_signal(Signal::FinishIndent);
-      current_indent_level = indent_level;
+      current_indent_level -= 1;
     }
     let mut parts = line[pos..].split(placeholder_text).enumerate().peekable();
     while let Some((i, part)) = parts.next() {

--- a/tests/specs/external_formatter/html.txt
+++ b/tests/specs/external_formatter/html.txt
@@ -49,3 +49,51 @@ export const Layout = (props: Props) =>
             </body>
         </html>
     `;
+
+== should format html with multi-level indent jumps (regression for deno#29963) ==
+const a = html`<a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+  <path d="" />
+</svg></a>`;
+[expect]
+const a = html`
+    <a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+            <path d="" />
+        </svg></a>
+`;
+
+== should format html with multi-level indent jumps and an expression placeholder ==
+const a = html`<a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+  <path d="${pathData}" />
+</svg></a>`;
+[expect]
+const a = html`
+    <a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+            <path d="${pathData}" />
+        </svg></a>
+`;
+
+== should format html with three-level indent jump in a single transition ==
+const a = html`<a><b><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+  <path d="" />
+</svg></b></a>`;
+[expect]
+const a = html`
+    <a><b><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+                <path d="" />
+            </svg></b></a>
+`;
+
+== should format html with multiple multi-level indent jumps in the same template ==
+const a = html`<a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+  <path d="" />
+</svg><svg viewBox="0 0 32 32" width="30" height="30" fill="blue">
+  <circle r="5" />
+</svg></a>`;
+[expect]
+const a = html`
+    <a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+            <path d="" />
+        </svg><svg viewBox="0 0 32 32" width="30" height="30" fill="blue">
+            <circle r="5" />
+        </svg></a>
+`;


### PR DESCRIPTION
When the external formatter's output transitions by more than one indent
level between adjacent lines, `maybe_gen_tagged_tpl_with_external_formatter`
emitted only a single `StartIndent`/`FinishIndent` signal but jumped
`current_indent_level` directly to the new level. The end-of-template
cleanup (`while current_indent_level > 0 { FinishIndent }`) then emitted
one `FinishIndent` per level, leaving the IR unbalanced and panicking
dprint-core's writer with `finish_indent was called without a
corresponding start_indent`.

For example, the input

```js
const a = html`<a><svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
  <path d="" />
</svg></a>`;
```

produces lines at indent levels 0 → 2 → 1 from `markup_fmt`. The old code
pushed one StartIndent (for 0→2) and one FinishIndent (2→1), but cleanup
pushed two more FinishIndents (the 1→0 in the `while` loop plus the
trailing one closing the initial StartIndent) — three finishes against two
starts, which trips the assertion in `dprint-core`.

The fix replaces the single-step `if`/`else if` with `while` loops so
multi-level transitions emit one signal per level. Four regression specs
are added to `tests/specs/external_formatter/html.txt` covering the
original case, the same with an `${expr}` placeholder, a three-level
single-line jump (`<a><b><svg>…`), and a template with sibling
multi-level jumps. Each case panics on the existing code and passes on
the fix; the rest of the spec suite (648 tests) continues to pass.

Fixes denoland/deno#29963.