### PR TITLE
fix: add trailing comma after wrapped arrow expression body in call (#696)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7618,10 +7618,6 @@ where
           items.push_signal(Signal::SpaceIfNotTrailing);
         }
         items.push_condition(conditions::indent_if_start_of_line(generated_node));
-        // When the arrow's expression body forced the call onto multiple lines and
-        // the trailing-comma configuration is `always`, emit the trailing comma
-        // before the closing paren (issue #696). `onlyMultiLine` historically did
-        // not emit a comma here, so preserve that behavior to avoid churn.
         let trailing_break_items = {
           let mut break_items = PrintItems::new();
           if matches!(trailing_commas, TrailingCommas::Always) {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7618,6 +7618,18 @@ where
           items.push_signal(Signal::SpaceIfNotTrailing);
         }
         items.push_condition(conditions::indent_if_start_of_line(generated_node));
+        // When the arrow's expression body forced the call onto multiple lines and
+        // the trailing-comma configuration is `always`, emit the trailing comma
+        // before the closing paren (issue #696). `onlyMultiLine` historically did
+        // not emit a comma here, so preserve that behavior to avoid churn.
+        let trailing_break_items = {
+          let mut break_items = PrintItems::new();
+          if matches!(trailing_commas, TrailingCommas::Always) {
+            break_items.push_sc(sc!(","));
+          }
+          break_items.push_signal(Signal::NewLine);
+          break_items
+        };
         items.push_condition(if_true_or(
           "isDifferentLineAndStartLineIndentation",
           Rc::new(move |context| {
@@ -7627,7 +7639,7 @@ where
             let is_different_start_line_indentation = start_lsil != context.writer_info.line_start_indent_level;
             Some(is_different_line && is_different_start_line_indentation)
           }),
-          Signal::NewLine.into(),
+          trailing_break_items,
           if space_around { Signal::SpaceIfNotTrailing.into() } else { PrintItems::new() },
         ));
       } else {

--- a/tests/specs/general/Arguments_TrailingCommas_Always.txt
+++ b/tests/specs/general/Arguments_TrailingCommas_Always.txt
@@ -1,0 +1,73 @@
+~~ lineWidth: 60, trailingCommas: always ~~
+== should add trailing comma to single-arg call ==
+foo(x);
+
+[expect]
+foo(x,);
+
+== should add trailing comma to multi-arg call ==
+foo(a, b, c);
+
+[expect]
+foo(a, b, c,);
+
+== should add trailing comma in multi-line call ==
+foo(
+    aLongerName,
+    anotherLongerName
+);
+
+[expect]
+foo(
+    aLongerName,
+    anotherLongerName,
+);
+
+== should add trailing comma after arrow expression body when call wraps (issue #696) ==
+[1, 2, 3].map(value =>
+    value == "a quite long paragraph with many words")
+
+[expect]
+[1, 2, 3,].map(value =>
+    value == "a quite long paragraph with many words",
+);
+
+== should add trailing comma after block-bodied arrow ==
+foo(
+    (v) => {
+        return v;
+    }
+)
+
+[expect]
+foo(
+    (v,) => {
+        return v;
+    },
+);
+
+== should not add trailing comma after rest argument in call when never-trailing applies ==
+foo(...args);
+
+[expect]
+foo(...args,);
+
+== should not add trailing comma in dynamic import ==
+import(
+    "myreallylongdynamicallyloadedmodulename"
+);
+
+[expect]
+import(
+    "myreallylongdynamicallyloadedmodulename"
+);
+
+== should add trailing comma when last arg is arrow whose body wraps ==
+a.b().c({ d: 1 }, () =>
+    doSomethingThatDoesNotFitOnTheSameLine())
+
+[expect]
+a.b().c(
+    { d: 1, },
+    () => doSomethingThatDoesNotFitOnTheSameLine(),
+);

--- a/tests/specs/issues/issue0696.txt
+++ b/tests/specs/issues/issue0696.txt
@@ -1,0 +1,34 @@
+~~ lineWidth: 60, trailingCommas: always ~~
+== should add trailing comma after arrow expression body when call breaks across lines (issue #696) ==
+const test = ["a","b","c"].map(value =>
+    value == "a quite long paragraph with many words")
+
+[expect]
+const test = ["a", "b", "c",].map(value =>
+    value == "a quite long paragraph with many words",
+);
+
+== should add trailing comma after nested expression body that wraps ==
+longCallExpression(value =>
+    someVeryLongCondition && anotherCondition)
+
+[expect]
+longCallExpression(value =>
+    someVeryLongCondition && anotherCondition,
+);
+
+== should not add trailing comma when arrow body stays on the same line ==
+foo(v => v);
+
+[expect]
+foo(v => v);
+
+== should keep dynamic import without trailing comma ==
+import(
+    "myreallylongdynamicallyloadedmodulename"
+);
+
+[expect]
+import(
+    "myreallylongdynamicallyloadedmodulename"
+);


### PR DESCRIPTION
Fixes #696.

---

Transparency note: This PR was prepared with AI assistance (Claude).

---

## Problem

With `trailingCommas: always`:

```ts
const test = ["a","b","c"].map(value =>
  value == "a quite long paragraph with many words")
```

…formats to (no comma after the arrow body):

```ts
const test = ["a", "b", "c",].map(value =>
  value == "a quite long paragraph with many words"
)
```

Issue reports the expected output should be:

```ts
const test = ["a", "b", "c",].map(value =>
  value == "a quite long paragraph with many words",
)
```

## Root cause

`gen_parameters_or_arguments` (src/generation/generate.rs) has a special branch for calls with a single argument that is an arrow function with an expression body:

```rust
if !force_use_new_lines && nodes.len() == 1 && is_arrow_function_with_expr_body(nodes[0]) {
    …
    items.push_condition(if_true_or(
      "isDifferentLineAndStartLineIndentation",
      …,
      Signal::NewLine.into(),                    // <-- true branch: just newline
      if space_around { … } else { … },
    ));
}
```

When the arrow body forces the call onto multiple lines, the true branch emits a bare `Signal::NewLine` before the closing paren — no comma, regardless of `trailingCommas`. The fallthrough `gen_separated_values` branch (which honors `trailingCommas` via `separator: trailing_commas.into()`) is bypassed.

## Fix

Inject `,` into the true branch when `trailingCommas` resolves to `always`:

```rust
let trailing_break_items = {
  let mut break_items = PrintItems::new();
  if matches!(trailing_commas, TrailingCommas::Always) {
    break_items.push_sc(sc!(","));
  }
  break_items.push_signal(Signal::NewLine);
  break_items
};
items.push_condition(if_true_or(
  "isDifferentLineAndStartLineIndentation",
  …,
  trailing_break_items,
  …,
));
```

Scope is limited to `always`. `onlyMultiLine` keeps existing behavior — extending it would update several existing specs (issue105, issue165, JsxElement_MultiLineParens_Never, Arguments_SpaceAround_True) and might surprise users running the default config. Could be revisited as a follow-up.

## Tests

Corner-case probe also based on prettier's [tests/format/js/trailing-comma](https://github.com/prettier/prettier/tree/main/tests/format/js/trailing-comma) (function-calls.js, dynamic-import.js, jsx.js).