### PR TITLE
fix: keep space between `for` and `await` regardless of spaceAfterForKeyword (#692)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -5137,12 +5137,13 @@ fn gen_for_of_stmt<'a>(node: &ForOfStmt<'a>, context: &mut Context<'a>) -> Print
   items.push_info(start_header_ln);
   items.push_info(start_header_lsil);
   items.push_sc(sc!("for"));
-  if context.config.for_of_statement_space_after_for_keyword {
-    items.push_space();
-  }
   if node.is_await() {
     // todo: generate comments around await token range
-    items.push_sc(sc!("await "));
+    items.push_space();
+    items.push_sc(sc!("await"));
+  }
+  if context.config.for_of_statement_space_after_for_keyword {
+    items.push_space();
   }
   let inner_header_range = SourceRange::new(node.left.start(), node.right.end());
   items.extend(gen_node_in_parens(

--- a/tests/specs/statements/forOfStatement/ForOfStatement_All.txt
+++ b/tests/specs/statements/forOfStatement/ForOfStatement_All.txt
@@ -48,6 +48,26 @@ for await (const t of test) {
 for await (const t of test) {
 }
 
+== should format for await with empty body ==
+for await (const x of arr);
+
+[expect]
+for await (const x of arr);
+
+== should format for await with binding identifier inside async function ==
+async function foo() {
+    for await (num of asyncIterable) {
+        console.log(num);
+    }
+}
+
+[expect]
+async function foo() {
+    for await (num of asyncIterable) {
+        console.log(num);
+    }
+}
+
 == should print a nested variable declaration with semi-colon ==
 for (const t of test) {
     const u = 5;

--- a/tests/specs/statements/forOfStatement/ForOfStatement_SpaceAfterForKeyword_False.txt
+++ b/tests/specs/statements/forOfStatement/ForOfStatement_SpaceAfterForKeyword_False.txt
@@ -10,3 +10,13 @@ for(const t of test) {
     a;
     b;
 }
+
+== should keep space between `for` and `await` (issue #692) ==
+for await (const t of test) {
+    a;
+}
+
+[expect]
+for await(const t of test) {
+    a;
+}

--- a/tests/specs/statements/forOfStatement/ForOfStatement_SpaceAfterForKeyword_False.txt
+++ b/tests/specs/statements/forOfStatement/ForOfStatement_SpaceAfterForKeyword_False.txt
@@ -20,3 +20,23 @@ for await (const t of test) {
 for await(const t of test) {
     a;
 }
+
+== should handle for await with binding identifier ==
+async function foo() {
+    for await (num of asyncIterable) {
+        console.log(num);
+    }
+}
+
+[expect]
+async function foo() {
+    for await(num of asyncIterable) {
+        console.log(num);
+    }
+}
+
+== should handle for await with empty body ==
+for await (const x of arr);
+
+[expect]
+for await(const x of arr);


### PR DESCRIPTION
Fixes #692.

---

Transparency note: This PR was prepared with AI assistance (Claude).

---

## Problem

With `forOfStatement.spaceAfterForKeyword: false`:

```ts
for await (const userID of theMsg.recipientIDs)
```

formats to:

```ts
forawait (const userID of theMsg.recipientIDs)
```

`forawait` is not valid syntax.

## Root cause

`gen_for_of_stmt` (src/generation/generate.rs:5132) used to:

1. push `for`
2. push optional space if `spaceAfterForKeyword`
3. if `is_await`, push literal `"await "` (with trailing space)

With `spaceAfterForKeyword: false` and `is_await: true` the sequence becomes `"for" + "await "` -> `forawait `.

The space between `for` and `await` is mandatory regardless of the config flag — the flag should only control the space between the keyword sequence (`for` or `for await`) and the open paren.

## Fix

Reorder so the space between `for` and `await` is always emitted, then apply `spaceAfterForKeyword` after the keyword sequence:

```rust
items.push_sc(sc!("for"));
if node.is_await() {
  items.push_space();
  items.push_sc(sc!("await"));
}
if context.config.for_of_statement_space_after_for_keyword {
  items.push_space();
}
```

Resulting matrix:

| spaceAfterForKeyword | plain | `for await` |
|---|---|---|
| true | `for (…)` | `for await (…)` |
| false | `for(…)` | `for await(…)` |

## Tests

Extended `tests/specs/statements/forOfStatement/ForOfStatement_SpaceAfterForKeyword_False.txt` with the `for await` regression case. The existing `should format with the await keyword` case in `ForOfStatement_All.txt` already pins the `true` (default) branch.

`cargo test --release` passes.