### PR TITLE
feat: detect more tagged template patterns for external formatter (#658)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3126,26 +3126,59 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
 
 /// Normalizes the type of embedded language in a tagged template literal.
 fn normalize_embedded_language_type<'a>(node: &TaggedTpl<'a>) -> Option<&'a str> {
-  match node.tag {
-    Expr::Ident(ident) => return Some(ident.sym().as_str()),
-    Expr::Member(member_expr) => {
-      if let Expr::Ident(ident) = member_expr.obj {
-        if ident.sym().as_str() == "styled" {
-          return Some("css"); // styled.foo`...`
-        }
+  normalize_tag_expr(node.tag)
+}
+
+fn normalize_tag_expr<'a>(tag: Expr<'a>) -> Option<&'a str> {
+  match tag {
+    Expr::Ident(ident) => {
+      // alias `gql` to `graphql` so external formatters only need to handle one key
+      if ident.sym().as_str() == "gql" {
+        Some("graphql")
+      } else {
+        Some(ident.sym().as_str())
       }
-      None
     }
-    Expr::Call(call_expr) => {
-      if let Callee::Expr(Expr::Ident(ident)) = call_expr.callee {
-        if ident.sym().as_str() == "styled" {
-          return Some("css"); // styled(Button)`...`
-        }
-      }
-      None
-    }
+    Expr::Member(member_expr) => normalize_member_tag(member_expr),
+    Expr::Call(call_expr) => match call_expr.callee {
+      // styled(Button)`...`
+      Callee::Expr(Expr::Ident(ident)) if ident.sym().as_str() == "styled" => Some("css"),
+      // styled.foo.attrs({})`...`, styled(Component).attrs({})`...`, Component.extend.attrs({})`...`
+      Callee::Expr(Expr::Member(member_expr)) => normalize_member_tag(member_expr),
+      _ => None,
+    },
     _ => None,
   }
+}
+
+fn normalize_member_tag<'a>(member_expr: &MemberExpr<'a>) -> Option<&'a str> {
+  match member_expr.obj {
+    // styled.foo`...`
+    Expr::Ident(ident) if ident.sym().as_str() == "styled" => Some("css"),
+    // graphql.experimental`...`
+    Expr::Ident(ident) if ident.sym().as_str() == "graphql" => Some("graphql"),
+    // <UpperCaseIdent>.extend`...`  e.g. `Button.extend`
+    Expr::Ident(ident) if member_prop_name(&member_expr.prop) == Some("extend") && starts_with_uppercase(ident.sym().as_str()) => Some("css"),
+    // styled.foo.attrs({})`...`, styled(Component).attrs({})`...`, Component.extend.attrs({})`...`
+    Expr::Member(inner_member) => normalize_member_tag(inner_member),
+    Expr::Call(call_expr) => match call_expr.callee {
+      Callee::Expr(Expr::Ident(ident)) if ident.sym().as_str() == "styled" => Some("css"),
+      Callee::Expr(Expr::Member(inner_member)) => normalize_member_tag(inner_member),
+      _ => None,
+    },
+    _ => None,
+  }
+}
+
+fn member_prop_name<'a>(prop: &MemberProp<'a>) -> Option<&'a str> {
+  match prop {
+    MemberProp::Ident(ident) => Some(ident.sym().as_str()),
+    _ => None,
+  }
+}
+
+fn starts_with_uppercase(name: &str) -> bool {
+  name.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false)
 }
 
 fn gen_tagged_tpl<'a>(node: &TaggedTpl<'a>, context: &mut Context<'a>) -> PrintItems {

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3036,8 +3036,16 @@ fn gen_spread_element<'a>(node: &SpreadElement<'a>, context: &mut Context<'a>) -
 /// Formats the tagged template literal using an external formatter.
 /// Detects the type of embedded language automatically.
 fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, context: &mut Context<'a>) -> Option<PrintItems> {
-  let external_formatter = context.external_formatter.as_ref()?;
   let embedded_lang = normalize_embedded_language_type(node)?;
+  maybe_gen_tpl_with_external_formatter(node.tpl, embedded_lang, context)
+}
+
+/// Shared backbone for embedded-language formatting. Substitutes `${expr}` with
+/// placeholders, sends the resulting text to the host's external formatter, and
+/// stitches expressions back in at the placeholder positions. Used by both the
+/// tagged-template path and the `graphql(\`...\`)` call-argument path.
+fn maybe_gen_tpl_with_external_formatter<'a>(tpl: &Tpl<'a>, embedded_lang: &str, context: &mut Context<'a>) -> Option<PrintItems> {
+  let external_formatter = context.external_formatter.as_ref()?;
 
   let placeholder_css = "@dpr1nt_";
   let placeholder_other = "dpr1nt_";
@@ -3047,8 +3055,8 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
     _ => placeholder_other,
   };
   let text = capacity_builder::StringBuilder::<String>::build(|builder| {
-    let expr_len = node.tpl.exprs.len();
-    for (i, quasi) in node.tpl.quasis.iter().enumerate() {
+    let expr_len = tpl.exprs.len();
+    for (i, quasi) in tpl.quasis.iter().enumerate() {
       builder.append(quasi.raw().as_str());
       if i < expr_len {
         builder.append(placeholder_text);
@@ -3068,7 +3076,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
     Ok(formatted_tpl) => formatted_tpl?.replace("\\", r"\\"),
     Err(err) => {
       context.diagnostics.push(context::GenerateDiagnostic {
-        message: format!("Error formatting tagged template literal at line {}: {}", node.start_line() + 1, err),
+        message: format!("Error formatting tagged template literal at line {}: {}", tpl.start_line() + 1, err),
       });
       return None;
     }
@@ -3107,7 +3115,7 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
       }
       if parts.peek().is_some() {
         items.push_sc(sc!("${"));
-        items.extend(gen_node(node.tpl.exprs[index].into(), context));
+        items.extend(gen_node(tpl.exprs[index].into(), context));
         items.push_sc(sc!("}"));
         pos = end + placeholder_text.len();
         index += 1;
@@ -3122,6 +3130,22 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   items.push_signal(Signal::FinishIndent);
   items.push_sc(sc!("`"));
   Some(items)
+}
+
+/// Detects whether a bare template literal is in a position where the host should
+/// format its contents (currently only `graphql(\`...\`)` — direct call argument
+/// to a `graphql` identifier), and returns the language key if so.
+fn detect_embedded_lang_for_call_arg_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
+  // template literal arguments live inside an `ExprOrSpread` wrapper.
+  let expr_or_spread = tpl.parent().to::<ExprOrSpread>()?;
+  if expr_or_spread.spread().is_some() {
+    return None;
+  }
+  let call_expr = expr_or_spread.parent().to::<CallExpr>()?;
+  match call_expr.callee {
+    Callee::Expr(Expr::Ident(ident)) if ident.sym().as_str() == "graphql" => Some("graphql"),
+    _ => None,
+  }
 }
 
 /// Normalizes the type of embedded language in a tagged template literal.
@@ -3153,8 +3177,10 @@ fn normalize_tag_expr<'a>(tag: Expr<'a>) -> Option<&'a str> {
 
 fn normalize_member_tag<'a>(member_expr: &MemberExpr<'a>) -> Option<&'a str> {
   match member_expr.obj {
-    // styled.foo`...`
+    // styled.foo`...`, styled["a"]`...`
     Expr::Ident(ident) if ident.sym().as_str() == "styled" => Some("css"),
+    // css.global`...`, css.<anything>`...`  (matches emotion's `css.global` and similar)
+    Expr::Ident(ident) if ident.sym().as_str() == "css" => Some("css"),
     // graphql.experimental`...`
     Expr::Ident(ident) if ident.sym().as_str() == "graphql" => Some("graphql"),
     // <UpperCaseIdent>.extend`...`  e.g. `Button.extend`
@@ -3207,6 +3233,13 @@ fn gen_tagged_tpl<'a>(node: &TaggedTpl<'a>, context: &mut Context<'a>) -> PrintI
 }
 
 fn gen_tpl<'a>(node: &Tpl<'a>, context: &mut Context<'a>) -> PrintItems {
+  // Route through the external formatter when the surrounding context selects an
+  // embedded language for this bare template literal (e.g. `graphql(`...`)`).
+  if let Some(lang) = detect_embedded_lang_for_call_arg_tpl(node) {
+    if let Some(formatted) = maybe_gen_tpl_with_external_formatter(node, lang, context) {
+      return formatted;
+    }
+  }
   gen_template_literal(
     node.quasis.iter().map(|&n| n.into()).collect(),
     node.exprs.iter().map(|x| x.into()).collect(),

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3135,6 +3135,23 @@ fn maybe_gen_tpl_with_external_formatter<'a>(tpl: &Tpl<'a>, embedded_lang: &str,
 /// Detects whether a bare template literal is in a position where the host should
 /// format its contents (currently only `graphql(\`...\`)` — direct call argument
 /// to a `graphql` identifier), and returns the language key if so.
+/// Walks the parent chain of a bare template literal looking for surrounding
+/// context that selects an embedded language (e.g. JSX `css` prop, styled-jsx
+/// `<style jsx>{`...`}</style>`, Angular `@Component({ template/styles })`,
+/// `graphql(`...`)` call argument).
+fn detect_embedded_lang_for_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
+  if let Some(lang) = detect_embedded_lang_for_call_arg_tpl(tpl) {
+    return Some(lang);
+  }
+  if let Some(lang) = detect_embedded_lang_for_jsx_tpl(tpl) {
+    return Some(lang);
+  }
+  if let Some(lang) = detect_embedded_lang_for_angular_component_tpl(tpl) {
+    return Some(lang);
+  }
+  None
+}
+
 fn detect_embedded_lang_for_call_arg_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
   // template literal arguments live inside an `ExprOrSpread` wrapper.
   let expr_or_spread = tpl.parent().to::<ExprOrSpread>()?;
@@ -3144,6 +3161,84 @@ fn detect_embedded_lang_for_call_arg_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
   let call_expr = expr_or_spread.parent().to::<CallExpr>()?;
   match call_expr.callee {
     Callee::Expr(Expr::Ident(ident)) if ident.sym().as_str() == "graphql" => Some("graphql"),
+    _ => None,
+  }
+}
+
+/// Detects:
+/// - `<div css={`...`} />`   -> css   (emotion / theme-ui style prop)
+/// - `<style jsx>{`...`}</style>` and `<style jsx global>` -> css (styled-jsx)
+fn detect_embedded_lang_for_jsx_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
+  let container = tpl.parent().to::<JSXExprContainer>()?;
+  match container.parent() {
+    // css prop: `<X css={`...`}>`
+    Node::JSXAttr(attr) => {
+      if let JSXAttrName::Ident(name) = attr.name {
+        if name.sym().as_str() == "css" {
+          return Some("css");
+        }
+      }
+      None
+    }
+    // styled-jsx: `<style jsx>{`...`}</style>`
+    Node::JSXElement(element) => {
+      let opening = element.opening;
+      let JSXElementName::Ident(name) = opening.name else { return None };
+      if name.sym().as_str() != "style" {
+        return None;
+      }
+      let has_jsx_attr = opening.attrs.iter().any(|attr_or_spread| match attr_or_spread {
+        JSXAttrOrSpread::JSXAttr(attr) => matches!(attr.name, JSXAttrName::Ident(ident) if ident.sym().as_str() == "jsx"),
+        _ => false,
+      });
+      if has_jsx_attr { Some("css") } else { None }
+    }
+    _ => None,
+  }
+}
+
+/// Detects template literal in an Angular `@Component({ … })` decorator argument:
+/// - `template: `...`` -> html
+/// - `styles: `...`` and `styles: [`...`]` -> css
+fn detect_embedded_lang_for_angular_component_tpl<'a>(tpl: &Tpl<'a>) -> Option<&'a str> {
+  // walk up through an optional array literal (for the `styles: [`...`]` form),
+  // then to the KeyValueProp whose key tells us the language.
+  let (kv_prop, is_in_array) = {
+    let parent = tpl.parent();
+    if let Some(array_elem) = parent.to::<ExprOrSpread>() {
+      // array element form
+      if array_elem.spread().is_some() {
+        return None;
+      }
+      let array = array_elem.parent().to::<ArrayLit>()?;
+      let array_parent = array.parent();
+      let kv = array_parent.to::<KeyValueProp>()?;
+      (kv, true)
+    } else {
+      let kv = parent.to::<KeyValueProp>()?;
+      (kv, false)
+    }
+  };
+
+  let key = match kv_prop.key {
+    PropName::Ident(ident) => ident.sym().as_str(),
+    _ => return None,
+  };
+  let lang = match (key, is_in_array) {
+    ("template", false) => "html",
+    ("styles", _) => "css",
+    _ => return None,
+  };
+
+  // ensure we are inside `@Component({ … })`
+  let object_lit = kv_prop.parent();
+  let expr_or_spread = object_lit.parent().to::<ExprOrSpread>()?;
+  if expr_or_spread.spread().is_some() {
+    return None;
+  }
+  let call_expr = expr_or_spread.parent().to::<CallExpr>()?;
+  match call_expr.callee {
+    Callee::Expr(Expr::Ident(ident)) if ident.sym().as_str() == "Component" => Some(lang),
     _ => None,
   }
 }
@@ -3234,8 +3329,9 @@ fn gen_tagged_tpl<'a>(node: &TaggedTpl<'a>, context: &mut Context<'a>) -> PrintI
 
 fn gen_tpl<'a>(node: &Tpl<'a>, context: &mut Context<'a>) -> PrintItems {
   // Route through the external formatter when the surrounding context selects an
-  // embedded language for this bare template literal (e.g. `graphql(`...`)`).
-  if let Some(lang) = detect_embedded_lang_for_call_arg_tpl(node) {
+  // embedded language for this bare template literal (graphql(`...`), JSX `css`
+  // prop, styled-jsx `<style jsx>`, Angular `@Component({ template/styles })`).
+  if let Some(lang) = detect_embedded_lang_for_tpl(node) {
     if let Some(formatted) = maybe_gen_tpl_with_external_formatter(node, lang, context) {
       return formatted;
     }

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -12,8 +12,28 @@ fn external_formatter(lang: &str, text: String, config: &Configuration) -> Resul
     "css" => format_embedded_css(&text, config),
     "html" => format_html(&text, config),
     "sql" => format_sql(&text, config),
+    "graphql" => format_graphql_stub(&text, config),
     _ => Ok(None),
   }
+}
+
+/// Stub formatter for graphql — collapses whitespace runs to single spaces on each
+/// line. Just enough to verify that the `graphql` language key is reached from
+/// `gql`, `graphql`, and `graphql.experimental` tag patterns. Emits at 0-level
+/// indent; the host re-indents to match the surrounding code.
+fn format_graphql_stub(text: &str, _config: &Configuration) -> Result<Option<String>> {
+  // collect non-empty collapsed lines so the second formatting pass is idempotent
+  let lines: Vec<String> = text
+    .lines()
+    .map(|l| l.split_whitespace().collect::<Vec<_>>().join(" "))
+    .filter(|l| !l.is_empty())
+    .collect();
+  if lines.is_empty() {
+    return Ok(Some(String::new()));
+  }
+  let mut out = lines.join("\n");
+  out.push('\n');
+  Ok(Some(out))
 }
 
 fn format_embedded_css(text: &str, config: &Configuration) -> Result<Option<String>> {

--- a/tests/specs/external_formatter/css.txt
+++ b/tests/specs/external_formatter/css.txt
@@ -156,3 +156,38 @@ css`
         background-color: #86efac;
     }
 `;
+
+== should format css in styled.tag.attrs({})`...` ==
+styled.button.attrs({})`color : #222 ; background-color: #ccc ;`;
+[expect]
+styled.button.attrs({})`
+    color: #222;
+    background-color: #ccc;
+`;
+
+== should format css in styled(Component).attrs({})`...` ==
+styled(Button).attrs({})`color : #222 ;`;
+[expect]
+styled(Button).attrs({})`
+    color: #222;
+`;
+
+== should format css in <UpperIdent>.extend`...` (styled-components extend) ==
+const Tomato = Button.extend`color : tomato ; border-color: tomato ;`;
+[expect]
+const Tomato = Button.extend`
+    color: tomato;
+    border-color: tomato;
+`;
+
+== should format css in <UpperIdent>.extend.attrs({})`...` ==
+Button.extend.attrs({})`border-color : black ;`;
+[expect]
+Button.extend.attrs({})`
+    border-color: black;
+`;
+
+== should not treat lowercase ident with .extend as css ==
+foo.extend`color: red;`;
+[expect]
+foo.extend`color: red;`;

--- a/tests/specs/external_formatter/css.txt
+++ b/tests/specs/external_formatter/css.txt
@@ -191,3 +191,21 @@ Button.extend.attrs({})`
 foo.extend`color: red;`;
 [expect]
 foo.extend`color: red;`;
+
+== should format css in css.global`...` (emotion-style member) ==
+const reset = css.global`.reset { margin : 0 ; padding : 0 ; }`;
+[expect]
+const reset = css.global`
+    .reset {
+        margin: 0;
+        padding: 0;
+    }
+`;
+
+== should format css in styled["a"]`...` (computed member) ==
+const Anchor = styled["a"]`text-decoration : none ; color: #007bff ;`;
+[expect]
+const Anchor = styled["a"]`
+    text-decoration: none;
+    color: #007bff;
+`;

--- a/tests/specs/external_formatter/css.txt
+++ b/tests/specs/external_formatter/css.txt
@@ -209,3 +209,92 @@ const Anchor = styled["a"]`
     text-decoration: none;
     color: #007bff;
 `;
+
+== should format css in JSX css prop ==
+const x = <div css={`display:flex ; align-items:center ;`}>x</div>;
+[expect]
+const x = (
+    <div
+        css={`
+            display: flex;
+            align-items: center;
+        `}
+    >
+        x
+    </div>
+);
+
+== should not treat non-css JSX attribute template as css ==
+const x = <div data={`raw template`}>x</div>;
+[expect]
+const x = <div data={`raw template`}>x</div>;
+
+== should format css in styled-jsx `<style jsx>{`...`}</style>` ==
+const x = <style jsx>{`display:flex ; align-items:center ;`}</style>;
+[expect]
+const x = (
+    <style jsx>
+        {`
+            display: flex;
+            align-items: center;
+        `}
+    </style>
+);
+
+== should format css in styled-jsx `<style jsx global>{`...`}</style>` ==
+const x = <style jsx global>{`html { color: red; }`}</style>;
+[expect]
+const x = (
+    <style jsx global>
+        {`
+            html {
+                color: red;
+            }
+        `}
+    </style>
+);
+
+== should not treat `<style>{`...`}</style>` without jsx attribute as css ==
+const x = <style>{`html { color: red; }`}</style>;
+[expect]
+const x = <style>{`html { color: red; }`}</style>;
+
+== should format css in Angular @Component({ styles: `...` }) ==
+@Component({ selector: 'app', styles: `h1 { color : blue }` })
+export class A {}
+[expect]
+@Component({
+    selector: "app",
+    styles: `
+        h1 {
+            color: blue;
+        }
+    `,
+})
+export class A {}
+
+== should format css in Angular @Component({ styles: [`...`] }) ==
+@Component({ selector: 'app', styles: [`h1 { color : blue }`] })
+export class A {}
+[expect]
+@Component({
+    selector: "app",
+    styles: [`
+        h1 {
+            color: blue;
+        }
+    `],
+})
+export class A {}
+
+== should not treat non-Component decorator template as css/html ==
+decorate({ styles: `h1 { color: red }` });
+[expect]
+decorate({ styles: `h1 { color: red }` });
+
+== should not treat Angular @Component with computed `[styles]` key ==
+@Component({ [stylesKey]: `h1 { color : blue }` })
+export class A {}
+[expect]
+@Component({ [stylesKey]: `h1 { color : blue }` })
+export class A {}

--- a/tests/specs/external_formatter/graphql.txt
+++ b/tests/specs/external_formatter/graphql.txt
@@ -1,0 +1,20 @@
+== should format graphql in graphql`...` ==
+const q = graphql`query   User {   id   name   }`;
+[expect]
+const q = graphql`
+    query User { id name }
+`;
+
+== should format graphql in gql`...` (aliased) ==
+const q = gql`mutation   Foo {   bar   }`;
+[expect]
+const q = gql`
+    mutation Foo { bar }
+`;
+
+== should format graphql in graphql.experimental`...` ==
+graphql.experimental`mutation   MarkRead($input: Bar)   {   markRead(data: $input)  {  id  } }`;
+[expect]
+graphql.experimental`
+    mutation MarkRead($input: Bar) { markRead(data: $input) { id } }
+`;

--- a/tests/specs/external_formatter/graphql.txt
+++ b/tests/specs/external_formatter/graphql.txt
@@ -18,3 +18,35 @@ graphql.experimental`mutation   MarkRead($input: Bar)   {   markRead(data: $inpu
 graphql.experimental`
     mutation MarkRead($input: Bar) { markRead(data: $input) { id } }
 `;
+
+== should format graphql in graphql(`...`) call expression ==
+const q = graphql(`query   { users { name email } }`);
+[expect]
+const q = graphql(`
+    query { users { name email } }
+`);
+
+== should format graphql in graphql(schema, `...`) call expression ==
+graphql(schema, `mutation   MarkRead($input: Bar)   {   markRead(data: $input)  {  id  } }`);
+[expect]
+graphql(
+    schema,
+    `
+        mutation MarkRead($input: Bar) { markRead(data: $input) { id } }
+    `,
+);
+
+== should not treat gql(`...`) as graphql call expression ==
+gql(`query { users { name } }`);
+[expect]
+gql(`query { users { name } }`);
+
+== should not treat someFunction(`...`) as graphql call expression ==
+someFunction(`query { users { name } }`);
+[expect]
+someFunction(`query { users { name } }`);
+
+== should not treat ...spread template arg as graphql ==
+graphql(...args);
+[expect]
+graphql(...args);

--- a/tests/specs/external_formatter/html.txt
+++ b/tests/specs/external_formatter/html.txt
@@ -1,3 +1,27 @@
+== should format html in Angular @Component({ template: `...` }) ==
+@Component({ selector: 'app', template: `<h1>{{title}}</h1>` })
+export class A {}
+[expect]
+@Component({
+    selector: "app",
+    template: `
+        <h1>{{title}}</h1>
+    `,
+})
+export class A {}
+
+== should not treat Angular @Component({ template }) with computed key as html ==
+@Component({ [templateKey]: `<h1>x</h1>` })
+export class A {}
+[expect]
+@Component({ [templateKey]: `<h1>x</h1>` })
+export class A {}
+
+== should not treat non-Component decorator template as html ==
+decorate({ template: `<h1>x</h1>` });
+[expect]
+decorate({ template: `<h1>x</h1>` });
+
 == should format html in html`...` ==
 let htmlString = html`<body><header>HEADER</header><main>Hello there!</main><footer>FOOTER</footer></body>`;
 [expect]


### PR DESCRIPTION
Refs #658, #9, #643.

---

Transparency note: This PR was prepared with AI assistance (Claude).

---

The external-formatter infrastructure for tagged templates is in place — what was missing is detection for the embedded-language shapes prettier and oxfmt route automatically.

## Coverage matrix

| pattern | language | status |
|---|---|---|
| `css`...`` | css | existing |
| `styled.foo`...`` / `styled["x"]`...`` / `styled(X)`...`` | css | existing |
| `styled.foo.attrs({})`...`` / `styled(X).attrs({})`...`` | css | this PR |
| `UpperIdent.extend(.attrs({}))?`...`` | css | this PR |
| `css.global`...`` / `css.X`...`` | css | this PR |
| `<X css={`...`} />` | css | this PR |
| `<style jsx>{`...`}</style>` (incl. `global`) | css | this PR |
| `@Component({ styles: `...` })` / `{ styles: [`...`] }` | css | this PR |
| `@Component({ template: `...` })` | html | this PR |
| `html`...`` / `sql`...`` | html / sql | existing |
| `graphql`...`` / `gql`...`` (aliased) | graphql | this PR |
| `graphql.experimental`...`` | graphql | this PR |
| `graphql(`...`)` / `graphql(x, `...`)` | graphql | this PR |
| `markdown`...`` / `md`...`` | passthrough | existing |

## How

- `normalize_member_tag` (recursive) handles the tagged-template shapes (styled / extend / graphql / css member chains).
- New `detect_embedded_lang_for_tpl` runs from `gen_tpl` for non-tagged shapes (call-arg, JSX, Angular) and walks the parent chain.
- Substitution + re-indent backbone extracted into shared `maybe_gen_tpl_with_external_formatter(tpl, lang, ctx)`.

Negative guards (each spec-pinned): `foo.extend` (lowercase), `gql(`...`)`, `someFunction(`...`)`, spread args, JSX attr ≠ `css`, `<style>` without `jsx` attr, non-`Component` callee, computed Angular keys.

## Tests

`tests/specs/external_formatter/{css,html,graphql}.txt` + a tiny graphql stub in `tests/spec_test.rs` (idempotent under format-twice). Patterns mirrored from prettier `src/language-js/embed/{css,graphql,utilities}.js` and oxfmt `apps/oxfmt/test/api/embedded_languages.test.ts`.

## Addresses

- #9 (`html`...`` formatting) — already worked via existing `Ident` pass-through; verified against the issue's repro.
- #643 (styled-components) — `styled.div`...`` already worked; this PR adds `Component.extend`, `.attrs({})` variants.
- #658 (umbrella) — detection layer now broadly covers prettier + oxfmt parity.

## Out of scope

- `src/wasm_plugin.rs:69` still passes `external_formatter: None`. Wiring through the Wasm boundary is a host-plugin protocol change — separate PR. Until that lands, only Rust-API consumers see embedded formatting.
- Bare `styled`...`` (oxfmt accepts, prettier doesn't).
- Language-comment opt-in (`/* GraphQL */` etc.).

`cargo test --release` clean.