### PR TITLE
fix: break container instead of expanding one of many object siblings (#641)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7912,10 +7912,7 @@ fn gen_separated_values<'a>(opts: GenSeparatedValuesParams<'a>, context: &mut Co
   gen_separated_values_with_result(opts, context).items
 }
 
-/// True when the value is an arrow / function expression (possibly wrapped in
-/// ExprOrSpread / ParenExpr). These are the prettier-style "last arg hugging"
-/// candidates that should keep inline-multi-line privileges even when there are
-/// other siblings that could also expand inline.
+/// Arrow / function expression (possibly wrapped) — kept inline-multi-line even with other siblings.
 fn is_function_hugging_candidate(value: &NodeOrSeparator) -> bool {
   fn is_arrow_or_fn(expr: Expr) -> bool {
     match expr {
@@ -7958,12 +7955,8 @@ fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, cont
           _ => false,
         })
         .collect();
-      // Count siblings that would compete for an inline-multi-line slot, but
-      // ignore arrow/function-expression last-arg "hugging" candidates — those
-      // are the canonical `Array.from(x, () => { ... })` / `foo(arg, () => {})`
-      // shape that prettier keeps single-line at the call level. Without this
-      // exclusion the array-of-objects fix from issue #641 would regress the
-      // last-arrow-arg case.
+      // If 2+ non-arrow siblings would each take the inline-multi-line slot,
+      // break the container instead of expanding only one (issue #641).
       let inline_multi_line_count = nodes
         .iter()
         .zip(inline_multi_line_flags.iter())

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7912,6 +7912,26 @@ fn gen_separated_values<'a>(opts: GenSeparatedValuesParams<'a>, context: &mut Co
   gen_separated_values_with_result(opts, context).items
 }
 
+/// True when the value is an arrow / function expression (possibly wrapped in
+/// ExprOrSpread / ParenExpr). These are the prettier-style "last arg hugging"
+/// candidates that should keep inline-multi-line privileges even when there are
+/// other siblings that could also expand inline.
+fn is_function_hugging_candidate(value: &NodeOrSeparator) -> bool {
+  fn is_arrow_or_fn(expr: Expr) -> bool {
+    match expr {
+      Expr::Arrow(_) | Expr::Fn(_) => true,
+      Expr::Paren(paren) => is_arrow_or_fn(paren.expr),
+      _ => false,
+    }
+  }
+  match value {
+    NodeOrSeparator::Node(Node::ArrowExpr(_)) | NodeOrSeparator::Node(Node::FnExpr(_)) => true,
+    NodeOrSeparator::Node(Node::ExprOrSpread(e)) => is_arrow_or_fn(e.expr),
+    NodeOrSeparator::Node(Node::ParenExpr(p)) => is_arrow_or_fn(p.expr),
+    _ => false,
+  }
+}
+
 fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, context: &mut Context<'a>) -> GenSeparatedValuesResult {
   let nodes = opts.nodes;
   let separator = opts.separator;
@@ -7931,15 +7951,34 @@ fn gen_separated_values_with_result<'a>(opts: GenSeparatedValuesParams<'a>, cont
       let is_multi_line_or_hanging = is_multi_line_or_hanging_ref.create_resolver();
       let mut generated_nodes = Vec::new();
       let nodes_count = nodes.len();
+      let inline_multi_line_flags: Vec<bool> = nodes
+        .iter()
+        .map(|value| match value {
+          NodeOrSeparator::Node(v) => allows_inline_multi_line(*v, context, nodes_count > 1),
+          _ => false,
+        })
+        .collect();
+      // Count siblings that would compete for an inline-multi-line slot, but
+      // ignore arrow/function-expression last-arg "hugging" candidates — those
+      // are the canonical `Array.from(x, () => { ... })` / `foo(arg, () => {})`
+      // shape that prettier keeps single-line at the call level. Without this
+      // exclusion the array-of-objects fix from issue #641 would regress the
+      // last-arrow-arg case.
+      let inline_multi_line_count = nodes
+        .iter()
+        .zip(inline_multi_line_flags.iter())
+        .filter(|(value, flag)| **flag && !is_function_hugging_candidate(value))
+        .count();
+      let allow_any_inline_multi_line = inline_multi_line_count <= 1;
 
       for (i, value) in nodes.into_iter().enumerate() {
         let node_index = match &sorted_indexes {
           Some(old_to_new_index) => *old_to_new_index.get(i).unwrap(),
           None => i,
         };
-        let (allow_inline_multi_line, allow_inline_single_line) = if let NodeOrSeparator::Node(value) = value {
-          let is_last_value = node_index + 1 == nodes_count; // allow the last node to be single line
-          (allows_inline_multi_line(value, context, nodes_count > 1), is_last_value)
+        let (allow_inline_multi_line, allow_inline_single_line) = if let NodeOrSeparator::Node(_) = value {
+          let is_last_value = node_index + 1 == nodes_count;
+          (allow_any_inline_multi_line && inline_multi_line_flags[i], is_last_value)
         } else {
           (false, false)
         };

--- a/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferSingleLine_True.txt
+++ b/tests/specs/expressions/ArrayExpression/ArrayExpression_PreferSingleLine_True.txt
@@ -33,7 +33,7 @@ const a = [
     ["123456", "123456"], //
 ];
 
-== should not be multi line if the objects are allowed to be inline multi-line ==
+== should break the container when multiple object siblings could each go inline multi-line (issue #641) ==
 const t = [{
     prop: 5
 }, {
@@ -41,11 +41,14 @@ const t = [{
 }];
 
 [expect]
-const t = [{
-    prop: 5,
-}, {
-    other: "string",
-}];
+const t = [
+    {
+        prop: 5,
+    },
+    {
+        other: "string",
+    },
+];
 
 == should maintain blank lines when exceeding the line width ==
 const t = [

--- a/tests/specs/issues/issue0520.txt
+++ b/tests/specs/issues/issue0520.txt
@@ -48,10 +48,10 @@ export const AID = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "organizationArn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "principalArn" },
-          }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "organizationArn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } },
+          ],
         },
       }],
     },
@@ -63,21 +63,24 @@ export const AcD = {
     "kd": "OperationDefinition",
     "operation": "query",
     "name": { "kd": "Name", "value": "Ac" },
-    "variableDefinitions": [{
-      "kd": "VariableDefinition",
-      "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "arns" } },
-      "type": {
-        "kd": "NonNullType",
+    "variableDefinitions": [
+      {
+        "kd": "VariableDefinition",
+        "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "arns" } },
         "type": {
-          "kd": "ListType",
-          "type": { "kd": "NonNullType", "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "Arn" } } },
+          "kd": "NonNullType",
+          "type": {
+            "kd": "ListType",
+            "type": { "kd": "NonNullType", "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "Arn" } } },
+          },
         },
       },
-    }, {
-      "kd": "VariableDefinition",
-      "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
-      "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "AcFilterInput" } },
-    }],
+      {
+        "kd": "VariableDefinition",
+        "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
+        "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "AcFilterInput" } },
+      },
+    ],
     "selectionSet": {
       "kd": "SelectionSet",
       "selections": [{
@@ -90,46 +93,49 @@ export const AcD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "appliedAces" },
-            "arguments": [{
-              "kd": "Argument",
-              "name": { "kd": "Name", "value": "filter" },
-              "value": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
-            }],
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "access" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [
-                    { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
-                    {
-                      "kd": "Field",
-                      "name": { "kd": "Name", "value": "assignedPrincipals" },
-                      "selectionSet": {
-                        "kd": "SelectionSet",
-                        "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
-                      },
-                    },
-                    { "kd": "Field", "name": { "kd": "Name", "value": "description" } },
-                    { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
-                    {
-                      "kd": "Field",
-                      "name": { "kd": "Name", "value": "target" },
-                      "selectionSet": {
-                        "kd": "SelectionSet",
-                        "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
-                      },
-                    },
-                  ],
-                },
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "appliedAces" },
+              "arguments": [{
+                "kd": "Argument",
+                "name": { "kd": "Name", "value": "filter" },
+                "value": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
               }],
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{
+                  "kd": "Field",
+                  "name": { "kd": "Name", "value": "access" },
+                  "selectionSet": {
+                    "kd": "SelectionSet",
+                    "selections": [
+                      { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                      {
+                        "kd": "Field",
+                        "name": { "kd": "Name", "value": "assignedPrincipals" },
+                        "selectionSet": {
+                          "kd": "SelectionSet",
+                          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
+                        },
+                      },
+                      { "kd": "Field", "name": { "kd": "Name", "value": "description" } },
+                      { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                      {
+                        "kd": "Field",
+                        "name": { "kd": "Name", "value": "target" },
+                        "selectionSet": {
+                          "kd": "SelectionSet",
+                          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
+                        },
+                      },
+                    ],
+                  },
+                }],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -202,15 +208,18 @@ export const OAcD = {
     "kd": "OperationDefinition",
     "operation": "query",
     "name": { "kd": "Name", "value": "OAc" },
-    "variableDefinitions": [{
-      "kd": "VariableDefinition",
-      "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "arn" } },
-      "type": { "kd": "NonNullType", "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "Arn" } } },
-    }, {
-      "kd": "VariableDefinition",
-      "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
-      "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "AcFilterInput" } },
-    }],
+    "variableDefinitions": [
+      {
+        "kd": "VariableDefinition",
+        "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "arn" } },
+        "type": { "kd": "NonNullType", "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "Arn" } } },
+      },
+      {
+        "kd": "VariableDefinition",
+        "variable": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
+        "type": { "kd": "NamedType", "name": { "kd": "Name", "value": "AcFilterInput" } },
+      },
+    ],
     "selectionSet": {
       "kd": "SelectionSet",
       "selections": [{
@@ -223,46 +232,49 @@ export const OAcD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "appliedAces" },
-            "arguments": [{
-              "kd": "Argument",
-              "name": { "kd": "Name", "value": "filter" },
-              "value": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
-            }],
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "access" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [
-                    { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
-                    {
-                      "kd": "Field",
-                      "name": { "kd": "Name", "value": "assignedPrincipals" },
-                      "selectionSet": {
-                        "kd": "SelectionSet",
-                        "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
-                      },
-                    },
-                    { "kd": "Field", "name": { "kd": "Name", "value": "description" } },
-                    { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
-                    {
-                      "kd": "Field",
-                      "name": { "kd": "Name", "value": "target" },
-                      "selectionSet": {
-                        "kd": "SelectionSet",
-                        "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
-                      },
-                    },
-                  ],
-                },
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "appliedAces" },
+              "arguments": [{
+                "kd": "Argument",
+                "name": { "kd": "Name", "value": "filter" },
+                "value": { "kd": "Variable", "name": { "kd": "Name", "value": "filter" } },
               }],
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{
+                  "kd": "Field",
+                  "name": { "kd": "Name", "value": "access" },
+                  "selectionSet": {
+                    "kd": "SelectionSet",
+                    "selections": [
+                      { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                      {
+                        "kd": "Field",
+                        "name": { "kd": "Name", "value": "assignedPrincipals" },
+                        "selectionSet": {
+                          "kd": "SelectionSet",
+                          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
+                        },
+                      },
+                      { "kd": "Field", "name": { "kd": "Name", "value": "description" } },
+                      { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                      {
+                        "kd": "Field",
+                        "name": { "kd": "Name", "value": "target" },
+                        "selectionSet": {
+                          "kd": "SelectionSet",
+                          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }],
+                        },
+                      },
+                    ],
+                  },
+                }],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -307,10 +319,11 @@ export const GetAcD = {
               "name": { "kd": "Name", "value": "role" },
               "selectionSet": {
                 "kd": "SelectionSet",
-                "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "roleId" } }, {
-                  "kd": "Field",
-                  "name": { "kd": "Name", "value": "applicationName" },
-                }, { "kd": "Field", "name": { "kd": "Name", "value": "roleName" } }],
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "roleId" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "applicationName" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "roleName" } },
+                ],
               },
             },
             {
@@ -361,10 +374,10 @@ export const UnassignAcD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "accessArn" },
-          }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "accessArn" } },
+          ],
         },
       }],
     },
@@ -383,20 +396,21 @@ export const ApsD = {
         "name": { "kd": "Name", "value": "applications" },
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "id" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "name" },
-          }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "roles" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "id" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "name" },
-              }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "id" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "roles" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "id" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                ],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -576,10 +590,10 @@ export const InviteXPrincipalD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "principalArn" },
-          }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } },
+          ],
         },
       }],
     },
@@ -598,24 +612,28 @@ export const ListIsD = {
         "name": { "kd": "Name", "value": "invitations" },
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "inviter" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "email" } }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "inviter" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "email" } }],
+              },
             },
-          }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "organization" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "name" },
-              }],
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "organization" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                ],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -644,17 +662,20 @@ export const MstmApsD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "mySystemAps" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "name" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "url" },
-              }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "mySystemAps" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "url" } },
+                ],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -683,27 +704,28 @@ export const OD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "name" },
-          }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "children" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "children" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-                    "kd": "Field",
-                    "name": { "kd": "Name", "value": "name" },
-                  }],
-                },
-              }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "children" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{
+                  "kd": "Field",
+                  "name": { "kd": "Name", "value": "children" },
+                  "selectionSet": {
+                    "kd": "SelectionSet",
+                    "selections": [
+                      { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                      { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                    ],
+                  },
+                }],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -727,10 +749,10 @@ export const OsD = {
             "name": { "kd": "Name", "value": "organizations" },
             "selectionSet": {
               "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "name" },
-              }],
+              "selections": [
+                { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+              ],
             },
           }],
         },
@@ -761,14 +783,17 @@ export const ResourceTreeD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "resourceTree" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "resourceTree" } }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "resourceTree" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "resourceTree" } }],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -800,17 +825,21 @@ export const SetUPrsD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "properties" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "isAcAdmin" },
-              }, { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "properties" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "isAcAdmin" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } },
+                ],
+              },
             },
-          }],
+          ],
         },
       }],
     },
@@ -842,10 +871,10 @@ export const UpdateDescD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "description" },
-          }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "description" } },
+          ],
         },
       }],
     },
@@ -877,10 +906,10 @@ export const UpdateNameD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "name" },
-          }],
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+          ],
         },
       }],
     },
@@ -909,133 +938,146 @@ export const UsAndItsD = {
         }],
         "selectionSet": {
           "kd": "SelectionSet",
-          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "invitations" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "createdAt" },
-              }, {
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "invitee" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "email" } }, {
+          "selections": [
+            { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "invitations" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [
+                  { "kd": "Field", "name": { "kd": "Name", "value": "invitationArn" } },
+                  { "kd": "Field", "name": { "kd": "Name", "value": "createdAt" } },
+                  {
                     "kd": "Field",
-                    "name": { "kd": "Name", "value": "principalArn" },
-                  }],
-                },
-              }],
-            },
-          }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "principals" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "principals" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [{
-                    "kd": "InlineFragment",
-                    "typeCondition": { "kd": "NamedType", "name": { "kd": "Name", "value": "XPrincipal" } },
+                    "name": { "kd": "Name", "value": "invitee" },
                     "selectionSet": {
                       "kd": "SelectionSet",
                       "selections": [
-                        { "kd": "Field", "name": { "kd": "Name", "value": "__typename" } },
-                        {
-                          "kd": "Field",
-                          "name": { "kd": "Name", "value": "contactInfo" },
-                          "selectionSet": {
-                            "kd": "SelectionSet",
-                            "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "name" } }, {
-                              "kd": "Field",
-                              "name": { "kd": "Name", "value": "email" },
-                            }],
-                          },
-                        },
-                        { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
-                        { "kd": "Field", "name": { "kd": "Name", "value": "createdAt" } },
-                        {
-                          "kd": "Field",
-                          "name": { "kd": "Name", "value": "properties" },
-                          "selectionSet": {
-                            "kd": "SelectionSet",
-                            "selections": [
-                              { "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } },
-                              { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } },
-                              { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalViewer" } },
-                              { "kd": "Field", "name": { "kd": "Name", "value": "isAcAdmin" } },
-                              { "kd": "Field", "name": { "kd": "Name", "value": "isAcViewer" } },
-                            ],
-                          },
-                        },
-                        { "kd": "Field", "name": { "kd": "Name", "value": "invitationStatus" } },
-                        {
-                          "kd": "Field",
-                          "name": { "kd": "Name", "value": "accesses" },
-                          "selectionSet": {
-                            "kd": "SelectionSet",
-                            "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-                              "kd": "Field",
-                              "name": { "kd": "Name", "value": "name" },
-                            }],
-                          },
-                        },
+                        { "kd": "Field", "name": { "kd": "Name", "value": "email" } },
+                        { "kd": "Field", "name": { "kd": "Name", "value": "principalArn" } },
                       ],
                     },
-                  }],
-                },
-              }],
+                  },
+                ],
+              },
             },
-          }, {
-            "kd": "Field",
-            "name": { "kd": "Name", "value": "self" },
-            "selectionSet": {
-              "kd": "SelectionSet",
-              "selections": [{
-                "kd": "Field",
-                "name": { "kd": "Name", "value": "principal" },
-                "selectionSet": {
-                  "kd": "SelectionSet",
-                  "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "arn" } }, {
-                    "kd": "InlineFragment",
-                    "typeCondition": { "kd": "NamedType", "name": { "kd": "Name", "value": "XPrincipal" } },
-                    "selectionSet": {
-                      "kd": "SelectionSet",
-                      "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "__typename" } }, {
-                        "kd": "Field",
-                        "name": { "kd": "Name", "value": "contactInfo" },
-                        "selectionSet": {
-                          "kd": "SelectionSet",
-                          "selections": [{ "kd": "Field", "name": { "kd": "Name", "value": "name" } }, {
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "principals" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{
+                  "kd": "Field",
+                  "name": { "kd": "Name", "value": "principals" },
+                  "selectionSet": {
+                    "kd": "SelectionSet",
+                    "selections": [{
+                      "kd": "InlineFragment",
+                      "typeCondition": { "kd": "NamedType", "name": { "kd": "Name", "value": "XPrincipal" } },
+                      "selectionSet": {
+                        "kd": "SelectionSet",
+                        "selections": [
+                          { "kd": "Field", "name": { "kd": "Name", "value": "__typename" } },
+                          {
                             "kd": "Field",
-                            "name": { "kd": "Name", "value": "email" },
-                          }],
-                        },
-                      }, {
-                        "kd": "Field",
-                        "name": { "kd": "Name", "value": "properties" },
+                            "name": { "kd": "Name", "value": "contactInfo" },
+                            "selectionSet": {
+                              "kd": "SelectionSet",
+                              "selections": [
+                                { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "email" } },
+                              ],
+                            },
+                          },
+                          { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                          { "kd": "Field", "name": { "kd": "Name", "value": "createdAt" } },
+                          {
+                            "kd": "Field",
+                            "name": { "kd": "Name", "value": "properties" },
+                            "selectionSet": {
+                              "kd": "SelectionSet",
+                              "selections": [
+                                { "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalViewer" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "isAcAdmin" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "isAcViewer" } },
+                              ],
+                            },
+                          },
+                          { "kd": "Field", "name": { "kd": "Name", "value": "invitationStatus" } },
+                          {
+                            "kd": "Field",
+                            "name": { "kd": "Name", "value": "accesses" },
+                            "selectionSet": {
+                              "kd": "SelectionSet",
+                              "selections": [
+                                { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                                { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    }],
+                  },
+                }],
+              },
+            },
+            {
+              "kd": "Field",
+              "name": { "kd": "Name", "value": "self" },
+              "selectionSet": {
+                "kd": "SelectionSet",
+                "selections": [{
+                  "kd": "Field",
+                  "name": { "kd": "Name", "value": "principal" },
+                  "selectionSet": {
+                    "kd": "SelectionSet",
+                    "selections": [
+                      { "kd": "Field", "name": { "kd": "Name", "value": "arn" } },
+                      {
+                        "kd": "InlineFragment",
+                        "typeCondition": { "kd": "NamedType", "name": { "kd": "Name", "value": "XPrincipal" } },
                         "selectionSet": {
                           "kd": "SelectionSet",
                           "selections": [
-                            { "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } },
-                            { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } },
-                            { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalViewer" } },
-                            { "kd": "Field", "name": { "kd": "Name", "value": "isAcAdmin" } },
-                            { "kd": "Field", "name": { "kd": "Name", "value": "isAcViewer" } },
+                            { "kd": "Field", "name": { "kd": "Name", "value": "__typename" } },
+                            {
+                              "kd": "Field",
+                              "name": { "kd": "Name", "value": "contactInfo" },
+                              "selectionSet": {
+                                "kd": "SelectionSet",
+                                "selections": [
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "name" } },
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "email" } },
+                                ],
+                              },
+                            },
+                            {
+                              "kd": "Field",
+                              "name": { "kd": "Name", "value": "properties" },
+                              "selectionSet": {
+                                "kd": "SelectionSet",
+                                "selections": [
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "isOwner" } },
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalAdmin" } },
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "isPrincipalViewer" } },
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "isAcAdmin" } },
+                                  { "kd": "Field", "name": { "kd": "Name", "value": "isAcViewer" } },
+                                ],
+                              },
+                            },
                           ],
                         },
-                      }],
-                    },
-                  }],
-                },
-              }],
+                      },
+                    ],
+                  },
+                }],
+              },
             },
-          }],
+          ],
         },
       }],
     },

--- a/tests/specs/issues/issue0641.txt
+++ b/tests/specs/issues/issue0641.txt
@@ -1,0 +1,76 @@
+~~ lineWidth: 80 ~~
+== should fully break array of objects when total exceeds line width (issue #641) ==
+const fpnMembershipTitles = [{ name: "FPN" }, { name: "FPN Class" }, { name: "Type" }, { name: "Description" }];
+
+[expect]
+const fpnMembershipTitles = [
+    { name: "FPN" },
+    { name: "FPN Class" },
+    { name: "Type" },
+    { name: "Description" },
+];
+
+== should fully break call with multiple object args when total exceeds line width ==
+foo({ name: "FPN" }, { name: "FPN Class" }, { name: "Type" }, { name: "Description" });
+
+[expect]
+foo(
+    { name: "FPN" },
+    { name: "FPN Class" },
+    { name: "Type" },
+    { name: "Description" },
+);
+
+== should keep hugging when only one sibling can go inline multi-line (last arg arrow) ==
+Array.from({}, _ => { return _ + 1; });
+
+[expect]
+Array.from({}, _ => {
+    return _ + 1;
+});
+
+== should keep hugging single-object arrays even when the object wraps ==
+const a = [{ veryLongKeyName: "veryLongValueThatGoesOnAndOn", anotherLongKey: 42 }];
+
+[expect]
+const a = [{
+    veryLongKeyName: "veryLongValueThatGoesOnAndOn",
+    anotherLongKey: 42,
+}];
+
+== should fully break tuple of object-types when too wide ==
+type T = [{ propOne: number; propTwo: number }, { propOne: number; propTwo: number }];
+
+[expect]
+type T = [
+    { propOne: number; propTwo: number },
+    { propOne: number; propTwo: number },
+];
+
+== should fully break array of arrays when total exceeds line width ==
+const grid = [["aaa", "bbb"], ["ccc", "ddd"], ["eee", "fff"], ["gggggg", "hhhhhh"], ["iiiiii", "jjjjjj"]];
+
+[expect]
+const grid = [
+    ["aaa", "bbb"],
+    ["ccc", "ddd"],
+    ["eee", "fff"],
+    ["gggggg", "hhhhhh"],
+    ["iiiiii", "jjjjjj"],
+];
+
+== should keep short array of objects on a single line ==
+const a = [{}, {}, {}];
+
+[expect]
+const a = [{}, {}, {}];
+
+== should preserve arrow-hugging when arrow is the only inline candidate ==
+something(arg1, arg2, () => {
+    doStuff();
+});
+
+[expect]
+something(arg1, arg2, () => {
+    doStuff();
+});

--- a/tests/specs/issues/old_repo/issue067.txt
+++ b/tests/specs/issues/old_repo/issue067.txt
@@ -20,15 +20,21 @@ call({
 }, "testing");
 
 == several object expressions ==
-call({
-    prop,
-}, {
-    prop,
-});
+call(
+    {
+        prop,
+    },
+    {
+        prop,
+    },
+);
 
 [expect]
-call({
-    prop,
-}, {
-    prop,
-});
+call(
+    {
+        prop,
+    },
+    {
+        prop,
+    },
+);

--- a/tests/specs/types/TupleType/TupleType_PreferSingleLine_True.txt
+++ b/tests/specs/types/TupleType/TupleType_PreferSingleLine_True.txt
@@ -18,7 +18,7 @@ type T = [
     number,
 ];
 
-== should not be multi line if the objects are allowed to be inline multi-line ==
+== should break the container when multiple object siblings could each go inline multi-line (issue #641) ==
 type T = [{
     prop: number
 }, {
@@ -26,8 +26,11 @@ type T = [{
 }];
 
 [expect]
-type T = [{
-    prop: number;
-}, {
-    other: string;
-}];
+type T = [
+    {
+        prop: number;
+    },
+    {
+        other: string;
+    },
+];


### PR DESCRIPTION
Fixes #641. Aligns layout with prettier.

---

Transparency note: This PR was prepared with AI assistance (Claude).

---

## Problem

```ts
const a = [{ name: "FPN" }, { name: "FPN Class" }, { name: "Type" }, { name: "Description" }];
```

formatted as (one sibling expanded inline, others stay inline):

```ts
const a = [{ name: "FPN" }, { name: "FPN Class" }, { name: "Type" }, {
  name: "Description",
}];
```

Prettier at the same width breaks the array fully.

## Fix

`gen_separated_values_with_result` previously set `allow_inline_multi_line=true` per node based on `allows_inline_multi_line`. When every sibling qualified, the resolver picked one to expand inline.

Now: precompute the flags, count siblings that would compete for the slot — excluding arrow / function expressions (the canonical `Array.from(x, () => { … })` hugging shape). If 2+ remain, none get the slot, so the container breaks.

## Behavior

| input | before | after |
|---|---|---|
| array/call/tuple with 2+ object siblings, too wide | last expanded inline | fully broken (prettier-aligned) |
| `Array.from(x, () => { body })` | hugged | **still hugs** |
| `[{ … one long obj … }]` | hugged | **still hugs** |

## Spec updates

Pinned old hugging shape; now pin new:

- `ArrayExpression_PreferSingleLine_True.txt`
- `issue0520.txt` (large nested-JSON snapshot)
- `old_repo/issue067.txt`
- `TupleType_PreferSingleLine_True.txt`

`issue0312.txt` is unchanged (arrow exclusion preserves it).

New: `issue0641.txt` — regression + preserved arrow-hugging + single-object-hugging + tuple/array-of-arrays variants. Patterns cross-referenced against prettier `tests/format/js/arrays`.

`cargo test --release` passes.