### PR TITLE
feat: add Tailwind class name sorting (#552)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ This uses the [swc](https://github.com/swc-project/swc) parser for TypeScript wr
 
 See the GitHub [releases](https://github.com/dprint/dprint-plugin-typescript/releases).
 
+## Configuration
+
+Set `jsx.sortClassNames` to `tailwind` to sort JSX `class` and `className` values using Tailwind CSS ordering.
+Helper calls and tagged templates are sorted only when their leading identifier is listed in `jsx.sortClassNames.functions`.
+
+```json
+{
+  "typescript": {
+    "jsx.sortClassNames": "tailwind",
+    "jsx.sortClassNames.functions": ["cn", "classnames", "tw"]
+  }
+}
+```
+
 ## Development
 
 The tests are in the `./tests/specs` folder. To run the tests, run `cargo test`.

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -60,6 +60,26 @@
         "description": "Prefers using single quotes except in scenarios where the string contains more single quotes than double quotes."
       }]
     },
+    "jsx.sortClassNames": {
+      "description": "How to sort JSX class attribute values.",
+      "type": "string",
+      "default": "maintain",
+      "oneOf": [{
+        "const": "maintain",
+        "description": "Maintains the current class name ordering."
+      }, {
+        "const": "tailwind",
+        "description": "Sorts class names using Tailwind CSS ordering."
+      }]
+    },
+    "jsx.sortClassNames.functions": {
+      "description": "Function names whose string arguments should be sorted as Tailwind class names.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "quoteProps": {
       "description": "Change when properties in objects are quoted.",
       "type": "string",
@@ -870,6 +890,12 @@
     },
     "jsx.multiLineParens": {
       "$ref": "#/definitions/jsx.multiLineParens"
+    },
+    "jsx.sortClassNames": {
+      "$ref": "#/definitions/jsx.sortClassNames"
+    },
+    "jsx.sortClassNames.functions": {
+      "$ref": "#/definitions/jsx.sortClassNames.functions"
     },
     "memberExpression.linePerExpression": {
       "$ref": "#/definitions/memberExpression.linePerExpression"

--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -73,7 +73,7 @@
       }]
     },
     "jsx.sortClassNames.functions": {
-      "description": "Function names whose string arguments should be sorted as Tailwind class names.",
+      "description": "Leading function or tag identifiers whose string arguments and template literals should be sorted as Tailwind class names.",
       "type": "array",
       "default": [],
       "items": {

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -123,6 +123,23 @@ impl ConfigurationBuilder {
     self.insert("jsx.multiLineParens", value.to_string().into())
   }
 
+  /// How to sort JSX class attribute values.
+  ///
+  /// Default: `JsxClassNamesSortOrder::Maintain`
+  pub fn jsx_sort_class_names(&mut self, value: JsxClassNamesSortOrder) -> &mut Self {
+    self.insert("jsx.sortClassNames", value.to_string().into())
+  }
+
+  /// Function names whose string arguments should be sorted as Tailwind class names.
+  ///
+  /// Default: `[]`
+  pub fn jsx_sort_class_names_functions(&mut self, value: Vec<String>) -> &mut Self {
+    self.insert(
+      "jsx.sortClassNames.functions",
+      ConfigKeyValue::Array(value.into_iter().map(ConfigKeyValue::String).collect()),
+    )
+  }
+
   /// Forces newlines surrounding the content of JSX elements.
   ///
   /// Default: `false`
@@ -1112,6 +1129,8 @@ mod tests {
       .quote_style(QuoteStyle::AlwaysDouble)
       .jsx_quote_style(JsxQuoteStyle::PreferSingle)
       .jsx_multi_line_parens(JsxMultiLineParens::Never)
+      .jsx_sort_class_names(JsxClassNamesSortOrder::Tailwind)
+      .jsx_sort_class_names_functions(vec!["cn".to_string()])
       .jsx_force_new_lines_surrounding_content(true)
       .jsx_bracket_position(SameOrNextLinePosition::Maintain)
       .jsx_opening_element_bracket_position(SameOrNextLinePosition::Maintain)
@@ -1305,7 +1324,7 @@ mod tests {
       .while_statement_space_around(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 182);
+    assert_eq!(inner_config.len(), 184);
     let diagnostics = resolve_config(inner_config, &Default::default()).diagnostics;
     assert_eq!(diagnostics.len(), 0);
   }

--- a/src/configuration/builder.rs
+++ b/src/configuration/builder.rs
@@ -130,7 +130,8 @@ impl ConfigurationBuilder {
     self.insert("jsx.sortClassNames", value.to_string().into())
   }
 
-  /// Function names whose string arguments should be sorted as Tailwind class names.
+  /// Leading function or tag identifiers whose string arguments and template literals should be sorted as
+  /// Tailwind class names.
   ///
   /// Default: `[]`
   pub fn jsx_sort_class_names_functions(&mut self, value: Vec<String>) -> &mut Self {

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -99,6 +99,9 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
     conditional_expression_line_per_expression: get_value(&mut config, "conditionalExpression.linePerExpression", true, &mut diagnostics),
     jsx_quote_style: get_value(&mut config, "jsx.quoteStyle", quote_style.to_jsx_quote_style(), &mut diagnostics),
     jsx_multi_line_parens: get_value(&mut config, "jsx.multiLineParens", JsxMultiLineParens::Prefer, &mut diagnostics),
+    jsx_sort_class_names: get_value(&mut config, "jsx.sortClassNames", JsxClassNamesSortOrder::Maintain, &mut diagnostics),
+    jsx_sort_class_names_functions: get_nullable_vec(&mut config, "jsx.sortClassNames.functions", get_string_config_value, &mut diagnostics)
+      .unwrap_or_default(),
     jsx_force_new_lines_surrounding_content: get_value(&mut config, "jsx.forceNewLinesSurroundingContent", false, &mut diagnostics),
     jsx_opening_element_bracket_position: get_value(&mut config, "jsxOpeningElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
     jsx_self_closing_element_bracket_position: get_value(&mut config, "jsxSelfClosingElement.bracketPosition", jsx_bracket_position, &mut diagnostics),
@@ -348,6 +351,19 @@ pub fn resolve_config(config: ConfigKeyMap, global_config: &GlobalConfiguration)
       if !config.contains_key(key) {
         config.insert(key.clone(), value.clone());
       }
+    }
+  }
+}
+
+fn get_string_config_value(value: ConfigKeyValue, index: usize, diagnostics: &mut Vec<ConfigurationDiagnostic>) -> Option<String> {
+  match value {
+    ConfigKeyValue::String(value) => Some(value),
+    _ => {
+      diagnostics.push(ConfigurationDiagnostic {
+        property_name: format!("jsx.sortClassNames.functions[{}]", index),
+        message: "Expected a string.".to_string(),
+      });
+      None
     }
   }
 }

--- a/src/configuration/types.rs
+++ b/src/configuration/types.rs
@@ -265,6 +265,18 @@ pub enum JsxMultiLineParens {
 
 generate_str_to_from![JsxMultiLineParens, [Never, "never"], [Prefer, "prefer"], [Always, "always"]];
 
+/// How to sort JSX class attribute values.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum JsxClassNamesSortOrder {
+  /// Maintains the current class name ordering.
+  Maintain,
+  /// Sorts class names using Tailwind CSS ordering.
+  Tailwind,
+}
+
+generate_str_to_from![JsxClassNamesSortOrder, [Maintain, "maintain"], [Tailwind, "tailwind"]];
+
 /// Whether to use semi-colons or commas.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -329,6 +341,10 @@ pub struct Configuration {
   pub jsx_quote_style: JsxQuoteStyle,
   #[serde(rename = "jsx.multiLineParens")]
   pub jsx_multi_line_parens: JsxMultiLineParens,
+  #[serde(rename = "jsx.sortClassNames")]
+  pub jsx_sort_class_names: JsxClassNamesSortOrder,
+  #[serde(rename = "jsx.sortClassNames.functions")]
+  pub jsx_sort_class_names_functions: Vec<String>,
   #[serde(rename = "jsx.forceNewLinesSurroundingContent")]
   pub jsx_force_new_lines_surrounding_content: bool,
   #[serde(rename = "jsxOpeningElement.bracketPosition")]

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3182,7 +3182,13 @@ fn gen_tpl<'a>(node: &Tpl<'a>, context: &mut Context<'a>) -> PrintItems {
 }
 
 fn gen_tpl_element<'a>(node: &TplElement<'a>, context: &mut Context<'a>) -> PrintItems {
-  gen_from_raw_string(node.text_fast(context.program))
+  let text = node.text_fast(context.program);
+  let text = if should_sort_template_literal_class_names(node, context) {
+    sort_tailwind_class_names(text)
+  } else {
+    text.to_string()
+  };
+  gen_from_raw_string(&text)
 }
 
 fn gen_template_literal<'a>(quasis: Vec<Node<'a>>, exprs: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItems {
@@ -4257,11 +4263,105 @@ fn gen_reg_exp_literal(node: &Regex, _: &mut Context) -> PrintItems {
 
 fn gen_string_literal<'a>(node: &Str<'a>, context: &mut Context<'a>) -> PrintItems {
   let string_value = string_literal::get_value(node, context);
+  let string_value = if should_sort_string_literal_class_names(node, context) {
+    sort_tailwind_class_names(&string_value)
+  } else {
+    string_value
+  };
   if node.parent().is::<JSXAttr>() {
     string_literal::gen_jsx_text(&string_value, context)
   } else {
     string_literal::gen_non_jsx_text(&string_value, context)
   }
+}
+
+fn should_sort_string_literal_class_names(node: &Str, context: &Context) -> bool {
+  should_sort_tailwind_class_names(context)
+    && (has_sortable_jsx_class_attr_ancestor(context) || has_sortable_class_name_function_ancestor(node.range(), context))
+}
+
+fn should_sort_template_literal_class_names(node: &TplElement, context: &Context) -> bool {
+  should_sort_tailwind_class_names(context)
+    && (has_sortable_jsx_class_attr_ancestor(context) || has_sortable_tagged_template_ancestor(context))
+    && !node.text_fast(context.program).contains("${")
+}
+
+fn should_sort_tailwind_class_names(context: &Context) -> bool {
+  context.config.jsx_sort_class_names == JsxClassNamesSortOrder::Tailwind
+}
+
+fn has_sortable_jsx_class_attr_ancestor(context: &Context) -> bool {
+  context
+    .parent_stack
+    .iter()
+    .any(|ancestor| ancestor.to::<JSXAttr>().is_some_and(|attr| should_sort_jsx_class_names(attr, context)))
+}
+
+fn should_sort_jsx_class_names(attr: &JSXAttr, context: &Context) -> bool {
+  context.config.jsx_sort_class_names == JsxClassNamesSortOrder::Tailwind && matches!(attr.name.text_fast(context.program), "class" | "className")
+}
+
+fn has_sortable_class_name_function_ancestor(node_range: SourceRange, context: &Context) -> bool {
+  if context.config.jsx_sort_class_names_functions.is_empty() {
+    return false;
+  }
+
+  context.parent_stack.iter().any(|ancestor| match ancestor {
+    Node::CallExpr(call_expr) => is_range_in_args(node_range, call_expr.args) && is_sortable_class_name_callee(call_expr.callee, context),
+    Node::OptCall(call_expr) => is_range_in_args(node_range, call_expr.args) && is_sortable_class_name_callee(Callee::Expr(call_expr.callee), context),
+    _ => false,
+  })
+}
+
+fn has_sortable_tagged_template_ancestor(context: &Context) -> bool {
+  if context.config.jsx_sort_class_names_functions.is_empty() {
+    return false;
+  }
+
+  context.parent_stack.iter().any(|ancestor| match ancestor {
+    Node::TaggedTpl(tagged_tpl) => is_sortable_class_name_expression(tagged_tpl.tag.text_fast(context.program), context),
+    _ => false,
+  })
+}
+
+fn is_range_in_args(node_range: SourceRange, args: &[&ExprOrSpread]) -> bool {
+  args.iter().any(|arg| contains_range(arg.range(), node_range))
+}
+
+fn contains_range(outer: SourceRange, inner: SourceRange) -> bool {
+  outer.start <= inner.start && inner.end <= outer.end
+}
+
+fn is_sortable_class_name_callee(callee: Callee, context: &Context) -> bool {
+  match callee {
+    Callee::Expr(expr) => is_sortable_class_name_expression(expr.text_fast(context.program), context),
+    _ => false,
+  }
+}
+
+fn is_sortable_class_name_expression(text: &str, context: &Context) -> bool {
+  get_leading_identifier(text)
+    .map(|name| context.config.jsx_sort_class_names_functions.iter().any(|function_name| function_name == name))
+    .unwrap_or(false)
+}
+
+fn get_leading_identifier(text: &str) -> Option<&str> {
+  let text = text.trim_start();
+  let mut chars = text.char_indices();
+  let (_, first_char) = chars.next()?;
+  if !is_identifier_start(first_char) {
+    return None;
+  }
+  let end = chars.find(|(_, c)| !is_identifier_continue(*c)).map(|(index, _)| index).unwrap_or(text.len());
+  Some(&text[..end])
+}
+
+fn is_identifier_start(c: char) -> bool {
+  c == '_' || c == '$' || c.is_ascii_alphabetic()
+}
+
+fn is_identifier_continue(c: char) -> bool {
+  is_identifier_start(c) || c.is_ascii_digit()
 }
 
 mod string_literal {

--- a/src/generation/sorting/mod.rs
+++ b/src/generation/sorting/mod.rs
@@ -1,5 +1,8 @@
 mod module_specifiers;
+mod tailwind_class_names;
 use module_specifiers::*;
+
+pub use tailwind_class_names::*;
 
 use deno_ast::view::*;
 use deno_ast::SourceRange;

--- a/src/generation/sorting/tailwind_class_names.rs
+++ b/src/generation/sorting/tailwind_class_names.rs
@@ -1,0 +1,835 @@
+use std::cmp::Ordering;
+
+const COMPONENTS_LAYER_CLASSES: &[&str] = &["container$"];
+
+const UTILITIES_LAYER_CLASSES: &[&str] = &[
+  "sr-only$",
+  "not-sr-only$",
+  "pointer-events-none$",
+  "pointer-events-auto$",
+  "visible$",
+  "invisible$",
+  "collapse$",
+  "static$",
+  "fixed$",
+  "absolute$",
+  "relative$",
+  "sticky$",
+  "inset-",
+  "inset-x-",
+  "inset-y-",
+  "start-",
+  "end-",
+  "top-",
+  "right-",
+  "bottom-",
+  "left-",
+  "isolate$",
+  "isolation-auto$",
+  "z-",
+  "order-",
+  "col-",
+  "col-start-",
+  "col-end-",
+  "row-",
+  "row-start-",
+  "row-end-",
+  "float-start$",
+  "float-end$",
+  "float-right$",
+  "float-left$",
+  "float-none$",
+  "clear-start$",
+  "clear-end$",
+  "clear-left$",
+  "clear-right$",
+  "clear-both$",
+  "clear-none$",
+  "m-",
+  "mx-",
+  "my-",
+  "ms-",
+  "me-",
+  "mt-",
+  "mr-",
+  "mb-",
+  "ml-",
+  "box-border$",
+  "box-content$",
+  "line-clamp-",
+  "line-clamp-none$",
+  "block$",
+  "inline-block$",
+  "inline$",
+  "flex$",
+  "inline-flex$",
+  "table$",
+  "inline-table$",
+  "table-caption$",
+  "table-cell$",
+  "table-column$",
+  "table-column-group$",
+  "table-footer-group$",
+  "table-header-group$",
+  "table-row-group$",
+  "table-row$",
+  "flow-root$",
+  "grid$",
+  "inline-grid$",
+  "contents$",
+  "list-item$",
+  "hidden$",
+  "aspect-",
+  "size-",
+  "h-",
+  "max-h-",
+  "min-h-",
+  "w-",
+  "min-w-",
+  "max-w-",
+  "flex-",
+  "flex-shrink$",
+  "flex-shrink-",
+  "shrink$",
+  "shrink-",
+  "flex-grow$",
+  "flex-grow-",
+  "grow$",
+  "grow-",
+  "basis-",
+  "table-auto$",
+  "table-fixed$",
+  "caption-top$",
+  "caption-bottom$",
+  "border-collapse$",
+  "border-separate$",
+  "border-spacing-",
+  "border-spacing-x-",
+  "border-spacing-y-",
+  "origin-",
+  "translate-x-",
+  "translate-y-",
+  "rotate-",
+  "skew-x-",
+  "skew-y-",
+  "scale-",
+  "scale-x-",
+  "scale-y-",
+  "transform$",
+  "transform-cpu$",
+  "transform-gpu$",
+  "transform-none$",
+  "animate-",
+  "cursor-",
+  "touch-auto$",
+  "touch-none$",
+  "touch-pan-x$",
+  "touch-pan-left$",
+  "touch-pan-right$",
+  "touch-pan-y$",
+  "touch-pan-up$",
+  "touch-pan-down$",
+  "touch-pinch-zoom$",
+  "touch-manipulation$",
+  "select-none$",
+  "select-text$",
+  "select-all$",
+  "select-auto$",
+  "resize-none$",
+  "resize-y$",
+  "resize-x$",
+  "resize$",
+  "snap-none$",
+  "snap-x$",
+  "snap-y$",
+  "snap-both$",
+  "snap-mandatory$",
+  "snap-proximity$",
+  "snap-start$",
+  "snap-end$",
+  "snap-center$",
+  "snap-align-none$",
+  "snap-normal$",
+  "snap-always$",
+  "scroll-m-",
+  "scroll-mx-",
+  "scroll-my-",
+  "scroll-ms-",
+  "scroll-me-",
+  "scroll-mt-",
+  "scroll-mr-",
+  "scroll-mb-",
+  "scroll-ml-",
+  "scroll-p-",
+  "scroll-px-",
+  "scroll-py-",
+  "scroll-ps-",
+  "scroll-pe-",
+  "scroll-pt-",
+  "scroll-pr-",
+  "scroll-pb-",
+  "scroll-pl-",
+  "list-inside$",
+  "list-outside$",
+  "list-",
+  "list-image-",
+  "appearance-none$",
+  "appearance-auto$",
+  "columns-",
+  "break-before-",
+  "break-inside-",
+  "break-after-",
+  "auto-cols-",
+  "grid-flow-row$",
+  "grid-flow-col$",
+  "grid-flow-dense$",
+  "grid-flow-row-dense$",
+  "grid-flow-col-dense$",
+  "auto-rows-",
+  "grid-cols-",
+  "grid-rows-",
+  "flex-row$",
+  "flex-row-reverse$",
+  "flex-col$",
+  "flex-col-reverse$",
+  "flex-wrap$",
+  "flex-wrap-reverse$",
+  "flex-nowrap$",
+  "place-content-",
+  "place-items-",
+  "content-",
+  "items-",
+  "justify-normal$",
+  "justify-start$",
+  "justify-end$",
+  "justify-center$",
+  "justify-between$",
+  "justify-around$",
+  "justify-evenly$",
+  "justify-stretch$",
+  "justify-items-",
+  "gap-",
+  "gap-x-",
+  "gap-y-",
+  "space-x-",
+  "space-y-",
+  "space-y-reverse$",
+  "space-x-reverse$",
+  "divide-x$",
+  "divide-x-",
+  "divide-y$",
+  "divide-y-",
+  "divide-y-reverse$",
+  "divide-x-reverse$",
+  "divide-solid$",
+  "divide-dashed$",
+  "divide-dotted$",
+  "divide-double$",
+  "divide-none$",
+  "divide-",
+  "divide-opacity-",
+  "place-self-",
+  "self-",
+  "justify-self-",
+  "overflow-auto$",
+  "overflow-hidden$",
+  "overflow-clip$",
+  "overflow-visible$",
+  "overflow-scroll$",
+  "overflow-x-",
+  "overflow-y-",
+  "overscroll-",
+  "overscroll-y-",
+  "overscroll-x-",
+  "scroll-auto$",
+  "scroll-smooth$",
+  "truncate$",
+  "overflow-ellipsis$",
+  "text-ellipsis$",
+  "text-clip$",
+  "hyphens-",
+  "whitespace-",
+  "text-wrap$",
+  "text-nowrap$",
+  "text-balance$",
+  "text-pretty$",
+  "break-normal$",
+  "break-words$",
+  "break-all$",
+  "break-keep$",
+  "rounded$",
+  "rounded-",
+  "rounded-s$",
+  "rounded-s-",
+  "rounded-e$",
+  "rounded-e-",
+  "rounded-t$",
+  "rounded-t-",
+  "rounded-r$",
+  "rounded-r-",
+  "rounded-b$",
+  "rounded-b-",
+  "rounded-l$",
+  "rounded-l-",
+  "rounded-ss$",
+  "rounded-ss-",
+  "rounded-se$",
+  "rounded-se-",
+  "rounded-ee$",
+  "rounded-ee-",
+  "rounded-es$",
+  "rounded-es-",
+  "rounded-tl$",
+  "rounded-tl-",
+  "rounded-tr$",
+  "rounded-tr-",
+  "rounded-br$",
+  "rounded-br-",
+  "rounded-bl$",
+  "rounded-bl-",
+  "border$",
+  "border-",
+  "border-x$",
+  "border-x-",
+  "border-y$",
+  "border-y-",
+  "border-s$",
+  "border-s-",
+  "border-e$",
+  "border-e-",
+  "border-t$",
+  "border-t-",
+  "border-r$",
+  "border-r-",
+  "border-b$",
+  "border-b-",
+  "border-l$",
+  "border-l-",
+  "border-solid$",
+  "border-dashed$",
+  "border-dotted$",
+  "border-double$",
+  "border-hidden$",
+  "border-none$",
+  "border-opacity-",
+  "bg-",
+  "bg-opacity-",
+  "from-",
+  "via-",
+  "to-",
+  "decoration-slice$",
+  "decoration-clone$",
+  "box-decoration-slice$",
+  "box-decoration-clone$",
+  "bg-fixed$",
+  "bg-local$",
+  "bg-scroll$",
+  "bg-clip-",
+  "bg-repeat$",
+  "bg-no-repeat$",
+  "bg-repeat-x$",
+  "bg-repeat-y$",
+  "bg-repeat-round$",
+  "bg-repeat-space$",
+  "bg-origin-",
+  "fill-",
+  "stroke-",
+  "object-contain$",
+  "object-cover$",
+  "object-fill$",
+  "object-none$",
+  "object-scale-down$",
+  "object-",
+  "p-",
+  "px-",
+  "py-",
+  "ps-",
+  "pe-",
+  "pt-",
+  "pr-",
+  "pb-",
+  "pl-",
+  "text-left$",
+  "text-center$",
+  "text-right$",
+  "text-justify$",
+  "text-start$",
+  "text-end$",
+  "indent-",
+  "align-baseline$",
+  "align-top$",
+  "align-middle$",
+  "align-bottom$",
+  "align-text-top$",
+  "align-text-bottom$",
+  "align-sub$",
+  "align-super$",
+  "align-",
+  "font-",
+  "text-",
+  "uppercase$",
+  "lowercase$",
+  "capitalize$",
+  "normal-case$",
+  "italic$",
+  "not-italic$",
+  "normal-nums$",
+  "ordinal$",
+  "slashed-zero$",
+  "lining-nums$",
+  "oldstyle-nums$",
+  "proportional-nums$",
+  "tabular-nums$",
+  "diagonal-fractions$",
+  "stacked-fractions$",
+  "leading-",
+  "tracking-",
+  "text-opacity-",
+  "underline$",
+  "overline$",
+  "line-through$",
+  "no-underline$",
+  "decoration-",
+  "decoration-solid$",
+  "decoration-double$",
+  "decoration-dotted$",
+  "decoration-dashed$",
+  "decoration-wavy$",
+  "underline-offset-",
+  "antialiased$",
+  "subpixel-antialiased$",
+  "placeholder-",
+  "placeholder-opacity-",
+  "caret-",
+  "accent-",
+  "opacity-",
+  "bg-blend-",
+  "mix-blend-",
+  "shadow$",
+  "shadow-",
+  "outline-none$",
+  "outline$",
+  "outline-dashed$",
+  "outline-dotted$",
+  "outline-double$",
+  "outline-",
+  "outline-offset-",
+  "ring$",
+  "ring-",
+  "ring-inset$",
+  "ring-opacity-",
+  "ring-offset-",
+  "blur$",
+  "blur-",
+  "brightness-",
+  "contrast-",
+  "drop-shadow$",
+  "drop-shadow-",
+  "grayscale$",
+  "grayscale-",
+  "hue-rotate-",
+  "invert$",
+  "invert-",
+  "saturate-",
+  "sepia$",
+  "sepia-",
+  "filter$",
+  "filter-none$",
+  "backdrop-blur$",
+  "backdrop-blur-",
+  "backdrop-brightness-",
+  "backdrop-contrast-",
+  "backdrop-grayscale$",
+  "backdrop-grayscale-",
+  "backdrop-hue-rotate-",
+  "backdrop-invert$",
+  "backdrop-invert-",
+  "backdrop-opacity-",
+  "backdrop-saturate-",
+  "backdrop-sepia$",
+  "backdrop-sepia-",
+  "backdrop-filter$",
+  "backdrop-filter-none$",
+  "transition$",
+  "transition-",
+  "delay-",
+  "duration-",
+  "ease-",
+  "will-change-",
+  "contain-",
+  "content-",
+  "forced-color-adjust-auto$",
+  "forced-color-adjust-none$",
+];
+
+const VARIANT_CLASSES: &[&str] = &[
+  "*",
+  "first-letter",
+  "first-line",
+  "marker",
+  "selection",
+  "file",
+  "placeholder",
+  "backdrop",
+  "before",
+  "after",
+  "first",
+  "last",
+  "only",
+  "odd",
+  "even",
+  "first-of-type",
+  "last-of-type",
+  "only-of-type",
+  "visited",
+  "target",
+  "open",
+  "default",
+  "checked",
+  "indeterminate",
+  "placeholder-shown",
+  "autofill",
+  "optional",
+  "required",
+  "valid",
+  "invalid",
+  "in-range",
+  "out-of-range",
+  "read-only",
+  "empty",
+  "focus-within",
+  "hover",
+  "focus",
+  "focus-visible",
+  "active",
+  "enabled",
+  "disabled",
+  "group-hover",
+  "group-focus",
+  "group-active",
+  "group",
+  "peer-hover",
+  "peer-focus",
+  "peer-active",
+  "peer",
+  "has",
+  "group-has",
+  "peer-has",
+  "aria",
+  "group-aria",
+  "peer-aria",
+  "data",
+  "group-data",
+  "peer-data",
+  "supports",
+  "motion-safe",
+  "motion-reduce",
+  "contrast-more",
+  "contrast-less",
+  "max-sm",
+  "max-md",
+  "max-lg",
+  "max-xl",
+  "max-2xl",
+  "max",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+  "min",
+  "portrait",
+  "landscape",
+  "ltr",
+  "rtl",
+  "dark",
+  "forced-colors",
+  "print",
+];
+
+pub fn sort_tailwind_class_names(class_names: &str) -> String {
+  let classes = class_names.split_whitespace().fold(Vec::new(), |mut classes, class_name| {
+    if !classes.contains(&class_name) {
+      classes.push(class_name);
+    }
+    classes
+  });
+  let mut custom_classes = Vec::new();
+  let mut tailwind_classes = Vec::new();
+
+  for class_name in classes {
+    match ClassInfo::from_class_name(class_name) {
+      Some(class_info) => tailwind_classes.push(class_info),
+      None => custom_classes.push(class_name),
+    }
+  }
+
+  tailwind_classes.sort_by(|a, b| a.text.cmp(b.text));
+  tailwind_classes.sort_by(compare_classes);
+
+  custom_classes.extend(tailwind_classes.into_iter().map(|class_info| class_info.text));
+  custom_classes.join(" ")
+}
+
+fn compare_classes(a: &ClassInfo, b: &ClassInfo) -> Ordering {
+  cmp_optional(a.has_arbitrary_variants(), b.has_arbitrary_variants(), Ordering::Greater, Ordering::Less)
+    .then_with(|| a.arbitrary_variants.len().cmp(&b.arbitrary_variants.len()))
+    .then_with(|| a.arbitrary_variants.cmp(&b.arbitrary_variants))
+    .then_with(|| cmp_optional(a.variant_weight.is_some(), b.variant_weight.is_some(), Ordering::Greater, Ordering::Less))
+    .then_with(|| a.layer_index.cmp(&b.layer_index))
+    .then_with(|| compare_variant_weights(a.variant_weight.as_deref(), b.variant_weight.as_deref()))
+    .then_with(|| a.utility_index.cmp(&b.utility_index))
+    .then_with(|| a.text.cmp(b.text))
+}
+
+fn cmp_optional(a: bool, b: bool, a_some_order: Ordering, b_some_order: Ordering) -> Ordering {
+  match (a, b) {
+    (true, true) | (false, false) => Ordering::Equal,
+    (true, false) => a_some_order,
+    (false, true) => b_some_order,
+  }
+}
+
+fn compare_variant_weights(a: Option<&[usize]>, b: Option<&[usize]>) -> Ordering {
+  match (a, b) {
+    (Some(a), Some(b)) => a.len().cmp(&b.len()).then_with(|| a.cmp(b)),
+    _ => Ordering::Equal,
+  }
+}
+
+struct ClassInfo<'a> {
+  text: &'a str,
+  variant_weight: Option<Vec<usize>>,
+  layer_index: usize,
+  utility_index: usize,
+  arbitrary_variants: Vec<&'a str>,
+}
+
+impl<'a> ClassInfo<'a> {
+  fn from_class_name(class_name: &'a str) -> Option<ClassInfo<'a>> {
+    let class_structure = tokenize_class(class_name)?;
+    let utility_info = get_utility_info(&class_structure.utility)?;
+    let mut arbitrary_variants = Vec::new();
+    let mut variants = Vec::new();
+
+    for variant in &class_structure.variants {
+      if variant.arbitrary {
+        arbitrary_variants.push(variant.text);
+      } else {
+        variants.push(*variant);
+      }
+    }
+
+    Some(ClassInfo {
+      text: class_name,
+      variant_weight: compute_variant_weight(&variants),
+      layer_index: utility_info.layer_index,
+      utility_index: utility_info.utility_index,
+      arbitrary_variants,
+    })
+  }
+
+  fn has_arbitrary_variants(&self) -> bool {
+    !self.arbitrary_variants.is_empty()
+  }
+}
+
+#[derive(Clone, Copy)]
+struct UtilityInfo {
+  layer_index: usize,
+  utility_index: usize,
+}
+
+fn get_utility_info(utility: &ClassSegment) -> Option<UtilityInfo> {
+  if utility.arbitrary {
+    return Some(UtilityInfo {
+      layer_index: 2,
+      utility_index: 0,
+    });
+  }
+
+  get_utility_info_from_layer(0, COMPONENTS_LAYER_CLASSES, utility.text).or_else(|| get_utility_info_from_layer(1, UTILITIES_LAYER_CLASSES, utility.text))
+}
+
+fn get_utility_info_from_layer(layer_index: usize, layer_classes: &[&str], utility_text: &str) -> Option<UtilityInfo> {
+  let mut longest_partial_match = None;
+  let mut longest_partial_match_len = 0;
+
+  for (utility_index, target) in layer_classes.iter().enumerate() {
+    match matches_utility_target(target, utility_text) {
+      UtilityMatch::Exact => return Some(UtilityInfo { layer_index, utility_index }),
+      UtilityMatch::Partial => {
+        if target.len() > longest_partial_match_len {
+          longest_partial_match = Some(UtilityInfo { layer_index, utility_index });
+          longest_partial_match_len = target.len();
+        }
+      }
+      UtilityMatch::None => {}
+    }
+  }
+
+  longest_partial_match
+}
+
+enum UtilityMatch {
+  Exact,
+  Partial,
+  None,
+}
+
+fn matches_utility_target(target: &str, utility_text: &str) -> UtilityMatch {
+  let target = target.strip_prefix('-').unwrap_or(target);
+  let utility_text = utility_text.strip_prefix('-').unwrap_or(utility_text);
+  if let Some(exact_target) = target.strip_suffix('$') {
+    if utility_text == exact_target {
+      UtilityMatch::Exact
+    } else {
+      UtilityMatch::None
+    }
+  } else if utility_text.starts_with(target) && utility_text != target {
+    UtilityMatch::Partial
+  } else {
+    UtilityMatch::None
+  }
+}
+
+fn compute_variant_weight(variants: &[ClassSegment]) -> Option<Vec<usize>> {
+  let mut variant_weight = Vec::new();
+  for variant in variants {
+    let Some(variant_index) = find_variant_position(variant.text) else {
+      continue;
+    };
+    if !variant_weight.contains(&variant_index) {
+      variant_weight.push(variant_index);
+    }
+  }
+  if variant_weight.is_empty() {
+    None
+  } else {
+    variant_weight.sort_unstable();
+    Some(variant_weight)
+  }
+}
+
+fn find_variant_position(variant_text: &str) -> Option<usize> {
+  let mut longest_partial_match = None;
+  let mut longest_partial_match_len = 0;
+
+  for (index, target) in VARIANT_CLASSES.iter().enumerate() {
+    match matches_variant_target(target, variant_text) {
+      VariantMatch::Exact => return Some(index),
+      VariantMatch::Partial => {
+        if target.len() > longest_partial_match_len {
+          longest_partial_match = Some(index);
+          longest_partial_match_len = target.len();
+        }
+      }
+      VariantMatch::None => {}
+    }
+  }
+
+  longest_partial_match
+}
+
+enum VariantMatch {
+  Exact,
+  Partial,
+  None,
+}
+
+fn matches_variant_target(target: &str, variant_text: &str) -> VariantMatch {
+  if target == variant_text || variant_text.strip_prefix(target).is_some_and(|rest| rest.starts_with("-[")) {
+    VariantMatch::Exact
+  } else if variant_text.starts_with(target) && variant_text != target {
+    VariantMatch::Partial
+  } else {
+    VariantMatch::None
+  }
+}
+
+#[derive(Clone, Copy)]
+struct ClassSegment<'a> {
+  arbitrary: bool,
+  text: &'a str,
+}
+
+struct ClassStructure<'a> {
+  variants: Vec<ClassSegment<'a>>,
+  utility: ClassSegment<'a>,
+}
+
+fn tokenize_class(class_name: &str) -> Option<ClassStructure<'_>> {
+  let mut arbitrary_block_depth = 0;
+  let mut delimiter_indexes = Vec::new();
+
+  for (index, byte) in class_name.bytes().enumerate() {
+    match byte {
+      b'[' => arbitrary_block_depth += 1,
+      b']' => {
+        if arbitrary_block_depth == 0 {
+          return None;
+        }
+        arbitrary_block_depth -= 1;
+      }
+      b':' if arbitrary_block_depth == 0 => delimiter_indexes.push(index),
+      _ => {}
+    }
+  }
+
+  if arbitrary_block_depth != 0 {
+    return None;
+  }
+
+  let mut segments = split_at_indexes(class_name, &delimiter_indexes)
+    .into_iter()
+    .map(|text| ClassSegment {
+      arbitrary: text.starts_with('['),
+      text,
+    })
+    .collect::<Vec<_>>();
+  let utility = segments.pop()?;
+  Some(ClassStructure { variants: segments, utility })
+}
+
+fn split_at_indexes<'a>(text: &'a str, indexes: &[usize]) -> Vec<&'a str> {
+  let mut segments = Vec::new();
+  let mut start_offset = 0;
+  let mut start = 0;
+
+  for &index in indexes {
+    if index > start {
+      segments.push(&text[start + start_offset..index]);
+    }
+    start_offset = 1;
+    start = index;
+  }
+
+  if start + start_offset < text.len() {
+    segments.push(&text[start + start_offset..]);
+  }
+
+  segments
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn should_sort_custom_classes_first() {
+    assert_eq!(sort_tailwind_class_names("px-2 foo p-4 bar"), "foo bar p-4 px-2");
+  }
+
+  #[test]
+  fn should_sort_variants_after_plain_utilities() {
+    assert_eq!(
+      sort_tailwind_class_names("hover:focus:m-2 foo hover:px-2 p-4"),
+      "foo p-4 hover:px-2 hover:focus:m-2",
+    );
+  }
+
+  #[test]
+  fn should_handle_colons_in_arbitrary_segments() {
+    assert_eq!(sort_tailwind_class_names("[&:hover]:p-4 flex"), "flex [&:hover]:p-4");
+  }
+}

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_Default.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_Default.txt
@@ -1,0 +1,6 @@
+-- file.jsx --
+== should keep class names unchanged by default ==
+const value = <div className="p-4 flex" />;
+
+[expect]
+const value = <div className="p-4 flex" />;

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_Tailwind.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_Tailwind.txt
@@ -1,0 +1,33 @@
+-- file.jsx --
+~~ jsx.sortClassNames: tailwind ~~
+== should sort className values using Tailwind order ==
+const value = <div className="p-4 flex bg-red-500 text-white" />;
+
+[expect]
+const value = <div className="flex bg-red-500 p-4 text-white" />;
+
+== should sort class attribute values ==
+const value = <div class="p-4 flex" />;
+
+[expect]
+const value = <div class="flex p-4" />;
+
+== should match Prettier public sorter examples ==
+const first = <div className="sm:bg-tomato bg-red-500" />;
+const second = <div className="p-4 m-2" />;
+
+[expect]
+const first = <div className="bg-red-500 sm:bg-tomato" />;
+const second = <div className="m-2 p-4" />;
+
+== should keep custom classes first in their original order ==
+const value = <div className="px-2 foo p-4 bar" />;
+
+[expect]
+const value = <div className="foo bar p-4 px-2" />;
+
+== should collapse whitespace and remove duplicate classes ==
+const value = <div className="  p-4  flex p-4  " />;
+
+[expect]
+const value = <div className="flex p-4" />;

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindExpressions.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindExpressions.txt
@@ -1,0 +1,19 @@
+-- file.jsx --
+~~ jsx.sortClassNames: tailwind ~~
+== should sort string literals inside className expression containers ==
+const value = <div className={cn("p-4 flex", active && "p-2 inline")} />;
+
+[expect]
+const value = <div className={cn("flex p-4", active && "inline p-2")} />;
+
+== should sort object keys inside className expression containers ==
+const value = <div className={cn({ "px-2 p-4": active })} />;
+
+[expect]
+const value = <div className={cn({ "p-4 px-2": active })} />;
+
+== should sort template literals inside className expression containers ==
+const value = <div className={`p-4 flex`} />;
+
+[expect]
+const value = <div className={`flex p-4`} />;

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindFunctions.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindFunctions.txt
@@ -1,0 +1,19 @@
+-- file.jsx --
+~~ { "jsx.sortClassNames": "tailwind", "jsx.sortClassNames.functions": ["cn", "classnames", "tw"] } ~~
+== should sort configured function call string arguments ==
+const value = cn("p-4 flex", classnames("p-2 inline"));
+
+[expect]
+const value = cn("flex p-4", classnames("inline p-2"));
+
+== should sort configured member expression calls by leading function name ==
+const value = cn.foo("p-4 flex");
+
+[expect]
+const value = cn.foo("flex p-4");
+
+== should sort configured tagged template literals ==
+const value = tw`p-4 flex`;
+
+[expect]
+const value = tw`flex p-4`;

--- a/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindFunctionsDefault.txt
+++ b/tests/specs/jsx/JsxAttribute/JsxAttribute_SortClassNames_TailwindFunctionsDefault.txt
@@ -1,0 +1,7 @@
+-- file.jsx --
+~~ jsx.sortClassNames: tailwind ~~
+== should not sort helper calls by default ==
+const value = cn("p-4 flex");
+
+[expect]
+const value = cn("p-4 flex");


### PR DESCRIPTION
Fixes #552. Adds opt-in Tailwind class sorting aligned with prettier-plugin-tailwindcss.

---

Transparency note: This PR was prepared with AI assistance (Claude).

---

## Problem

Tailwind users often rely on Prettier's Tailwind plugin to keep utility classes in a stable recommended order.

```tsx
const value = <div className="p-4 flex bg-red-500 text-white" />;
```

Currently dprint-plugin-typescript preserves the input order, so projects that use dprint cannot opt into that Tailwind ordering for JSX class attributes or common class helper calls.

## Fix

Add `jsx.sortClassNames` with a new `tailwind` value. The default remains `maintain`.

When enabled, the formatter sorts Tailwind class lists in:

- JSX `class` and `className` string attributes
- string literals, object keys, and simple template literals inside `className={...}` expression containers
- configured helper calls via `jsx.sortClassNames.functions`, for example `cn`, `classnames`, or `tw`
- configured tagged template literals via the same function list

The sorter follows the same broad behavior as prettier-plugin-tailwindcss for the covered cases: custom classes stay first, whitespace is collapsed, duplicate classes are removed, and variants sort after base utilities.

## Behavior

| input | config | after |
|---|---|---|
| `<div className="p-4 flex" />` | default | unchanged |
| `<div className="p-4 flex" />` | `jsx.sortClassNames: tailwind` | `<div className="flex p-4" />` |
| `className={cn("p-4 flex")}` | `jsx.sortClassNames: tailwind` | string inside expression sorted |
| `cn("p-4 flex")` | `jsx.sortClassNames.functions: ["cn"]` | `cn("flex p-4")` |
| `` tw`p-4 flex` `` | `jsx.sortClassNames.functions: ["tw"]` | `` tw`flex p-4` `` |

## Spec and docs updates

New JSX attribute specs cover:

- default no-op behavior
- Tailwind ordering for `class` and `className`
- public prettier-plugin-tailwindcss examples
- custom class ordering
- whitespace collapse and duplicate removal
- `className={...}` expression containers
- configured function calls and tagged templates

Docs updates cover:

- README configuration example
- generated schema descriptions for `jsx.sortClassNames` and `jsx.sortClassNames.functions`

Cross-referenced against prettier-plugin-tailwindcss docs/source and Oxc's Tailwind sorting tests.

`cargo test` passes.
