### PR TITLE
fix: preserve jsdoc markdown hard breaks

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -6961,21 +6961,50 @@ fn gen_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
 fn gen_js_doc_or_multiline_block(comment: &Comment, _context: &mut Context) -> PrintItems {
   debug_assert_eq!(comment.kind, CommentKind::Block);
   let is_js_doc = comment.text.starts_with('*');
-  return lines_to_print_items(is_js_doc, build_lines(comment));
+  return lines_to_print_items(is_js_doc, build_lines(comment, is_js_doc));
 
-  fn build_lines(comment: &Comment) -> Vec<&str> {
-    let mut lines: Vec<&str> = Vec::new();
+  fn build_lines(comment: &Comment, is_js_doc: bool) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let raw_lines = utils::split_lines(&comment.text)
+      .map(|line| {
+        let text = if line.line_index == 0 && !line.text.starts_with('*') {
+          line.text
+        } else {
+          &line.text[get_line_start_index(line.text)..]
+        };
+        (text, line.is_last)
+      })
+      .collect::<Vec<_>>();
+    let mut fence_marker = None;
 
-    for line in utils::split_lines(&comment.text) {
-      let text = if line.line_index == 0 && !line.text.starts_with('*') {
-        line.text
+    for (index, (text, is_last)) in raw_lines.iter().enumerate() {
+      let has_following_non_empty_line = raw_lines
+        .iter()
+        .skip(index + 1)
+        .any(|(text, _)| !text.trim().is_empty());
+      let line_fence_marker = get_markdown_fence_marker(text);
+      let preserve_hard_break = is_js_doc
+        && fence_marker.is_none()
+        && line_fence_marker.is_none()
+        && has_following_non_empty_line
+        && !is_markdown_indented_code_line(text);
+      let text = *text;
+      let text = if *is_last && !text.trim().is_empty() {
+        text.to_string()
       } else {
-        &line.text[get_line_start_index(line.text)..]
+        trim_end_preserving_markdown_hard_break(text, preserve_hard_break)
       };
-      let text = if line.is_last && !text.trim().is_empty() { text } else { text.trim_end() };
 
       if !text.is_empty() || !lines.last().map(|l| l.is_empty()).unwrap_or(false) {
         lines.push(text);
+      }
+
+      if let Some(marker) = line_fence_marker {
+        fence_marker = match fence_marker {
+          Some(current_marker) if current_marker == marker => None,
+          Some(current_marker) => Some(current_marker),
+          None => Some(marker),
+        };
       }
     }
 
@@ -6994,7 +7023,40 @@ fn gen_js_doc_or_multiline_block(comment: &Comment, _context: &mut Context) -> P
     0
   }
 
-  fn lines_to_print_items(is_js_doc: bool, lines: Vec<&str>) -> PrintItems {
+  fn get_markdown_fence_marker(text: &str) -> Option<char> {
+    let text = text.trim_start();
+    let marker = text.chars().next()?;
+    if marker != '`' && marker != '~' {
+      return None;
+    }
+    if text.chars().take_while(|&c| c == marker).count() >= 3 {
+      Some(marker)
+    } else {
+      None
+    }
+  }
+
+  fn is_markdown_indented_code_line(text: &str) -> bool {
+    let text = text.strip_prefix(' ').unwrap_or(text);
+    text.starts_with("    ") || text.starts_with('\t')
+  }
+
+  fn trim_end_preserving_markdown_hard_break(text: &str, preserve_hard_break: bool) -> String {
+    let trimmed = text.trim_end();
+    let trailing_space_count = text
+      .as_bytes()
+      .iter()
+      .rev()
+      .take_while(|&&byte| byte == b' ')
+      .count();
+    if preserve_hard_break && trailing_space_count >= 2 && !trimmed.is_empty() {
+      format!("{trimmed}\\")
+    } else {
+      trimmed.to_string()
+    }
+  }
+
+  fn lines_to_print_items(is_js_doc: bool, lines: Vec<String>) -> PrintItems {
     let mut items = PrintItems::new();
 
     items.push_sc(sc!("/*"));

--- a/tests/specs/comments/CommentBlocks_All.txt
+++ b/tests/specs/comments/CommentBlocks_All.txt
@@ -87,6 +87,20 @@ const t;
  */
 const t;
 
+== should not convert markdown hard line breaks in non-jsdoc block comments ==
+/*
+ * Does something.  
+ * Details here.
+ */
+const t;
+
+[expect]
+/*
+ * Does something.
+ * Details here.
+ */
+const t;
+
 == should format comments in arguments ==
 call(/* test */5);
 

--- a/tests/specs/comments/JSDocComments_All.txt
+++ b/tests/specs/comments/JSDocComments_All.txt
@@ -164,3 +164,45 @@ const test = 5;
  * Testing
  * **UNSTABLE** test */
 const test = 5;
+
+== should convert markdown hard line breaks in js doc ==
+/**
+ * Does something.  
+ * Details here.
+ */
+const test = 5;
+
+[expect]
+/**
+ * Does something.\
+ * Details here.
+ */
+const test = 5;
+
+== should not convert markdown hard line breaks on the last js doc content line ==
+/**
+ * Does something.  
+ */
+const test = 5;
+
+[expect]
+/**
+ * Does something.
+ */
+const test = 5;
+
+== should not convert trailing spaces in js doc fenced code blocks ==
+/**
+ * ```ts
+ * const value = "x";  
+ * ```
+ */
+const test = 5;
+
+[expect]
+/**
+ * ```ts
+ * const value = "x";
+ * ```
+ */
+const test = 5;

--- a/tests/specs/issues/deno/issue031831.txt
+++ b/tests/specs/issues/deno/issue031831.txt
@@ -1,0 +1,14 @@
+~~ deno: true ~~
+== should preserve markdown hard line breaks in jsdoc ==
+/**
+ * abc  
+ * def
+ */
+export function example() {}
+
+[expect]
+/**
+ * abc\
+ * def
+ */
+export function example() {}


### PR DESCRIPTION
Refs denoland/deno#31831.

JSDoc is commonly rendered as Markdown, but the TypeScript formatter currently trims two trailing spaces from non-final JSDoc lines. That removes Markdown hard line breaks. The Markdown plugin normalizes the same input to a backslash hard break, so this applies the same normalization to JSDoc lines while keeping non-JSDoc block comments on the existing trimming behavior.

The regression coverage also guards the main edge cases from the narrower behavior:

- converts a JSDoc Markdown hard break when another content line follows
- does not convert a hard break on the last meaningful JSDoc content line
- does not convert trailing spaces inside a fenced JSDoc code block
- does not convert hard breaks in non-JSDoc block comments

Tests:

- `cargo test --test specs issue031831`
- `cargo test --test specs JSDocComments_All`
- `cargo test --test specs CommentBlocks_All`
- `cargo test`
