### PR TITLE
fix: don't double backslash escapes in non-CSS embedded templates

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -3064,8 +3064,23 @@ fn maybe_gen_tagged_tpl_with_external_formatter<'a>(node: &TaggedTpl<'a>, contex
   .unwrap();
 
   // Then formats the text with the external formatter.
-  let formatted_tpl = match external_formatter(embedded_lang, text.replace(r"\\", "\\"), context.config) {
-    Ok(formatted_tpl) => formatted_tpl?.replace("\\", r"\\"),
+  //
+  // Only CSS needs the `\\` -> `\` round-trip, so the CSS parser sees escapes
+  // like Tailwind's `\\[\\#86efac\\]` as `\[\#86efac\]`. For other embedded
+  // languages the raw text must be passed through verbatim; unescaping there
+  // doubles lone escape sequences such as `\n` or `` \` `` (see
+  // denoland/deno#30103 and #30948).
+  let needs_unescape = embedded_lang == "css";
+  let input = if needs_unescape { text.replace(r"\\", "\\") } else { text };
+  let formatted_tpl = match external_formatter(embedded_lang, input, context.config) {
+    Ok(formatted_tpl) => {
+      let formatted = formatted_tpl?;
+      if needs_unescape {
+        formatted.replace("\\", r"\\")
+      } else {
+        formatted
+      }
+    }
     Err(err) => {
       context.diagnostics.push(context::GenerateDiagnostic {
         message: format!("Error formatting tagged template literal at line {}: {}", node.start_line() + 1, err),

--- a/tests/specs/external_formatter/html.txt
+++ b/tests/specs/external_formatter/html.txt
@@ -97,3 +97,10 @@ const a = html`
             <circle r="5" />
         </svg></a>
 `;
+
+== should preserve a lone newline escape, not double it (deno#30103) ==
+html`\n`;
+[expect]
+html`
+    \n
+`;


### PR DESCRIPTION
## Problem

When formatting embedded code in tagged templates, lone escape sequences get
their backslash doubled, which changes the meaning of the user's code:

```ts
html`\n`;                          // \n  ->  \\n
const s = html`<script>const d = fetch(\`\`);</script>`;  // \`  ->  \\`
```

## Root cause

`maybe_gen_tagged_tpl_with_external_formatter` unescapes `\\` -> `\` before
calling the external formatter and then re-escapes **every** `\` -> `\\`
afterwards. The blanket post-doubling also doubles lone escapes (`\n`, `` \` ``)
that were never part of a `\\` pair.

The `\\` -> `\` collapse is genuinely needed for **CSS**: the CSS parser cannot
parse the double-backslash form of escapes (e.g. Tailwind
`.bg-\\[\\#86efac\\]` errors; it needs `.bg-\[\#86efac\]`). But it must not be
applied to other embedded languages.

## Fix

Gate the `\\` <-> `\` round-trip to `embedded_lang == "css"`. Other languages
(html / xml / svg / sql) pass the raw text through verbatim, preserving their
escapes. The existing CSS `\\` (Tailwind) behavior is unchanged.

## Test

Added a regression spec to `tests/specs/external_formatter/html.txt` asserting
`` html`\n` `` stays `\n`. Verified it fails before the fix and passes after; the
existing CSS `\\` spec still passes.

---

This PR was authored and opened with AI assistance (Claude Code). The fix was
manually verified end-to-end against Deno's formatter (which embeds this plugin):
it resolves denoland/deno#30103 and denoland/deno#30948, with Deno's full `fmt`
spec suite passing.
