### PR TITLE
fix: surface error instead of panicking on unclosed exported namespace/module

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -170,4 +170,59 @@ mod test {
       "Error formatting tagged template literal at line 1: Syntax error from external formatter"
     );
   }
+
+  fn format_for_test(text: &str) -> Result<Option<String>> {
+    let config = crate::configuration::ConfigurationBuilder::new().build();
+    format_text(FormatTextOptions {
+      path: &std::path::PathBuf::from("test.ts"),
+      extension: None,
+      text: text.into(),
+      config: &config,
+      external_formatter: None,
+    })
+  }
+
+  #[test]
+  fn unclosed_exported_namespace_surfaces_error() {
+    // unclosed `export namespace`/`export module` is recovered by swc without a diagnostic,
+    // so it reaches code generation. https://github.com/dprint/dprint-plugin-typescript/issues/802
+    for text in [
+      "export namespace Foo {\n  const x = 1;\n",
+      "export module Foo {\n  const x = 1;\n",
+      // unclosed empty body
+      "export namespace Foo {\n",
+      // nested: the single close brace belongs to the inner block, so the outer is unclosed
+      "export namespace Foo {\n  export namespace Bar {\n    const x = 1;\n}\n",
+      // unclosed outer containing a complete inner construct
+      "export namespace Foo {\n  function bar() {}\n",
+      // dotted name desugars to a nested namespace declaration
+      "export namespace Foo.Bar {\n  const x = 1;\n",
+    ] {
+      let err = format_for_test(text).err().unwrap_or_else(|| panic!("expected an error for {text:?}"));
+      let message = err.to_string();
+      let expected_prefix = "Unexpected end of file. Expected a close brace token for the block starting on line ";
+      assert!(message.starts_with(expected_prefix), "unexpected message for {text:?}: {message}");
+    }
+
+    // pin the full message, including the (1-based) line of the unclosed block's open brace
+    assert_eq!(
+      format_for_test("export namespace Foo {\n  const x = 1;\n").unwrap_err().to_string(),
+      "Unexpected end of file. Expected a close brace token for the block starting on line 1."
+    );
+    assert_eq!(
+      format_for_test("\nexport namespace Foo {\n  const x = 1;\n").unwrap_err().to_string(),
+      "Unexpected end of file. Expected a close brace token for the block starting on line 2."
+    );
+  }
+
+  #[test]
+  fn closed_namespaces_still_format() {
+    // regression: well-formed module/namespace declarations must still format.
+    assert_eq!(format_for_test("export namespace Foo {}\n").unwrap(), None);
+    assert_eq!(format_for_test("export namespace Foo {\n  const x = 1;\n}\n").unwrap(), None);
+    assert_eq!(
+      format_for_test("export namespace Foo {\n  export namespace Bar {\n    const x = 1;\n  }\n}\n").unwrap(),
+      None
+    );
+  }
 }

--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -7233,11 +7233,18 @@ where
     .iter()
     .find(|t| t.token == Token::LBrace)
     .expect("Expected to find an open brace token.");
-  let close_brace_token = child_tokens
-    .iter()
-    .rev()
-    .find(|t| t.token == Token::RBrace)
-    .expect("Expected to find a close brace token.");
+  let close_brace_token = match child_tokens.iter().rev().find(|t| t.token == Token::RBrace) {
+    Some(close_brace_token) => close_brace_token,
+    None => {
+      context.diagnostics.push(context::GenerateDiagnostic {
+        message: format!(
+          "Unexpected end of file. Expected a close brace token for the block starting on line {}.",
+          open_brace_token.start_line_fast(context.program) + 1
+        ),
+      });
+      return items;
+    }
+  };
 
   items.extend(gen_brace_separator(
     GenBraceSeparatorOptions {


### PR DESCRIPTION
## Summary

Fixes #802.

Formatting a file with an unclosed **exported** `namespace`/`module` panicked with `Expected to find a close brace token.` instead of reporting a syntax error:

```ts
export namespace Foo {
  const x = 1;
```

### Root cause

swc's parser recovers from the missing `}` for the `export namespace`/`export module` case and produces a `TsModuleDecl` **without emitting any diagnostic** (verified: 0 diagnostics). The parse-time gate `ensure_no_specific_syntax_errors` therefore has nothing to filter, so code generation proceeds and `gen_membered_body` panics on `.expect("Expected to find a close brace token.")`.

Every other unclosed form (bare `namespace`, `declare namespace`/`module`/`global`, bare `module`, dotted `namespace Foo.Bar`) *does* emit an swc diagnostic and was already handled.

### Fix

When no close-brace token is found in `gen_membered_body`, push a generation diagnostic (which makes `generate` return an `Err`) instead of `.expect()`-panicking. This reuses the existing `context.diagnostics` error channel and, because it relies on the view's direct-token-ownership, also handles nested cases where the single `}` belongs to the inner block.

The resulting error is, e.g.:

```
Unexpected end of file. Expected a close brace token for the block starting on line 1.
```

### Tests

Added unit tests in `src/format_text.rs` covering the panic→error variants (simple, `export module`, empty body, nested, unclosed-outer-with-complete-inner, dotted name) — including exact-message assertions that pin the reported line — plus regression cases confirming well-formed namespaces still format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)